### PR TITLE
PoC provider

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Git attributes for cross-platform development
+* text=auto eol=lf
+
+# Ruby files
+*.rb text eol=lf
+*.gemspec text eol=lf
+Gemfile text eol=lf
+Rakefile text eol=lf
+
+# Shell scripts
+*.sh text eol=lf
+
+# Windows scripts
+*.ps1 text eol=crlf
+*.bat text eol=crlf
+
+# Documentation
+*.md text eol=lf
+*.txt text eol=lf
+
+# Binary files
+*.gem binary
+*.exe binary
+*.dll binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,90 @@
+# Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode,ruby,vagrant
+# Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode,ruby,vagrant
+
+### Ruby ###
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# Used by RuboCop. Remote config files pulled in from inherit_from directive.
+# .rubocop-https?--*
+
+### Vagrant ###
+# General
+.vagrant/
+
+# Log files (if you are creating logs in debug mode, uncomment this)
+# *.log
+
+### Vagrant Patch ###
+*.box
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,ruby,vagrant

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in vagrant-wsl2-provider.gemspec
+gemspec
+
+gem "rake", "~> 13.0"
+gem "rspec", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,35 @@
+PATH
+  remote: .
+  specs:
+    vagrant-wsl2-provider (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.6.2)
+    rake (13.3.0)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.6)
+
+PLATFORMS
+  x64-mingw-ucrt
+
+DEPENDENCIES
+  bundler (~> 2.0)
+  rake (~> 13.0)
+  rspec (~> 3.0)
+  vagrant-wsl2-provider!
+
+BUNDLED WITH
+   2.6.9

--- a/README.md
+++ b/README.md
@@ -82,3 +82,24 @@ Bug reports and pull requests are welcome on GitHub.
 ## License
 
 The gem is available as open source under the [MIT License](./LICENSE).
+
+## WSL2 Distribution Lifecycle
+
+  **Important:** WSL2 distributions behave differently from traditional VMs!
+
+  ### Automatic Sleep Mode
+  - WSL2 distributions automatically enter "stopped" state when no processes are running
+  - This is **normal behavior**, not a bug
+  - Unlike VMs, WSL2 distributions don't stay "running" idle
+
+  ### Vagrant Status Meanings
+  - `stopped` = Distribution exists, no active processes (ready to use)
+  - `running` = Distribution has active processes
+  - `not created` = Distribution doesn't exist
+
+  ### Typical Workflow
+  ```bash
+  vagrant up --provider=wsl2     # Creates distribution (shows "stopped")
+  vagrant ssh                    # Starts shell (shows "running")
+  exit                          # Shell closes (returns to "stopped")
+  vagrant status                # Shows "stopped" - this is normal!

--- a/README.md
+++ b/README.md
@@ -75,6 +75,77 @@ bundle install
 rake spec  # Run tests
 ```
 
+### Development with Live Reload
+
+For active development, you can create junction points to your working directory so changes are immediately reflected without reinstalling the plugin:
+
+```cmd
+# First, install the plugin once
+gem build vagrant-wsl2-provider.gemspec
+vagrant plugin install vagrant-wsl2-provider-0.1.0.gem
+
+# Remove the installed lib and locales directories
+rmdir "C:\Users\YourUsername\.vagrant.d\gems\3.1.3\gems\vagrant-wsl2-provider-0.1.0\lib"
+rmdir "C:\Users\YourUsername\.vagrant.d\gems\3.1.3\gems\vagrant-wsl2-provider-0.1.0\locales"
+
+# Create junction points to your development directories (no admin rights required)
+mklink /J "C:\Users\YourUsername\.vagrant.d\gems\3.1.3\gems\vagrant-wsl2-provider-0.1.0\lib" "D:\Code\Github\vagrant-wsl2-provider\lib"
+mklink /J "C:\Users\YourUsername\.vagrant.d\gems\3.1.3\gems\vagrant-wsl2-provider-0.1.0\locales" "D:\Code\Github\vagrant-wsl2-provider\locales"
+```
+
+Now any changes to `lib/` or `locales/` in your working directory are immediately visible to Vagrant without reinstalling.
+
+### Cleanup Helper Commands
+
+Clean up all WSL distributions (useful for testing):
+
+```powershell
+wsl -l | Select-String -Pattern '\S' | ForEach-Object { $name = $_.Line -replace '\*', '' -replace '\s*\(.*\)', '' -replace '\0', ''; if ($name.Trim()) { wsl --unregister $name.Trim() } }
+```
+
+**Warning:** This removes ALL WSL distributions on your system. Use with caution!
+
+## Known Issues
+
+### Legacy WSL Distributions
+
+Some WSL distributions use the legacy registration system and are not fully supported:
+
+**Affected distributions:**
+- Ubuntu-20.04, Ubuntu-22.04
+- OracleLinux_7_9, OracleLinux_8_10, OracleLinux_9_5
+
+**Issues:**
+- `--no-launch` flag does not properly register the distribution
+- Distributions require interactive setup (username/password prompt)
+- Provider cannot detect distribution after installation
+
+### SUSE Enterprise Distributions
+
+SUSE Linux Enterprise distributions may have guest detection issues:
+- SUSE-Linux-Enterprise-15-SP6
+- SUSE-Linux-Enterprise-15-SP7
+
+### Bleeding Edge Distributions
+
+Very recent distributions may have provisioning issues:
+- AlmaLinux-10, AlmaLinux-Kitten-10 (Ansible provisioner fails due to missing EPEL repositories)
+
+### Minimal Distributions
+
+Some distributions have minimal installations without common tools:
+- archlinux (missing `sudo` by default - Ansible provisioner fails)
+
+### Tested and Working Distributions
+
+The following distributions are fully tested and working with shell/file/ansible provisioners:
+- AlmaLinux-8, AlmaLinux-9
+- Debian
+- FedoraLinux-42
+- Ubuntu, Ubuntu-24.04
+- Kali-Linux
+- openSUSE-Tumbleweed
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# Vagrant WSL2 Provider
+
+A Vagrant provider plugin for managing WSL2 distributions on Windows.
+
+## Features
+
+- Create and manage WSL2 distributions through Vagrant
+- Support for WSL2 configuration (memory, CPU, version)
+- Integration with Vagrant's standard workflow
+- Cross-platform compatible (Windows-focused)
+
+## Installation
+
+Install the plugin using:
+
+```bash
+vagrant plugin install vagrant-wsl2-provider
+```
+
+Or install from source:
+
+```bash
+git clone https://github.com/LeeShan87/vagrant-wsl2-provider.git
+cd vagrant-wsl2-provider
+gem build vagrant-wsl2-provider.gemspec
+vagrant plugin install vagrant-wsl2-provider-0.1.0.gem
+```
+
+## Usage
+
+Create a `Vagrantfile` with the WSL2 provider:
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/focal64"  # Or any WSL2-compatible box
+
+  config.vm.provider "wsl2" do |wsl|
+    wsl.distribution_name = "my-dev-env"
+    wsl.version = 2
+    wsl.memory = 4096
+    wsl.cpus = 2
+    wsl.gui_support = true
+  end
+end
+```
+
+Then run:
+
+```bash
+vagrant up --provider=wsl2
+```
+
+## Configuration
+
+### Provider Options
+
+- `distribution_name`: Name of the WSL2 distribution (default: auto-generated)
+- `version`: WSL version (1 or 2, default: 2)
+- `memory`: Memory limit in MB (default: 4096)
+- `cpus`: Number of CPUs (default: 2)
+- `gui_support`: Enable WSLg GUI support (default: false)
+
+## Requirements
+
+- Windows 10/11 with WSL2 enabled
+- Vagrant 2.2+
+- WSL2 kernel installed
+
+## Development
+
+After checking out the repo, run:
+
+```bash
+bundle install
+rake spec  # Run tests
+```
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub.
+
+## License
+
+The gem is available as open source under the [MIT License](./LICENSE).

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,17 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec
+
+desc "Build and install the plugin locally"
+task :install_local do
+  sh "gem build vagrant-wsl2-provider.gemspec"
+  sh "vagrant plugin install vagrant-wsl2-provider-*.gem"
+end
+
+desc "Uninstall the plugin"
+task :uninstall do
+  sh "vagrant plugin uninstall vagrant-wsl2-provider"
+end

--- a/lib/vagrant-wsl2-provider.rb
+++ b/lib/vagrant-wsl2-provider.rb
@@ -1,0 +1,8 @@
+require "vagrant-wsl2-provider/version"
+require "vagrant-wsl2-provider/plugin"
+
+module VagrantPlugins
+  module WSL2
+    # Plugin entry point
+  end
+end

--- a/lib/vagrant-wsl2-provider/action/create.rb
+++ b/lib/vagrant-wsl2-provider/action/create.rb
@@ -1,0 +1,45 @@
+require "vagrant/action/builder"
+
+module VagrantPlugins
+  module WSL2
+    module Action
+      class Create
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          machine = env[:machine]
+          config = machine.provider_config
+          driver = env[:wsl2_driver]
+
+          env[:ui].info "Creating WSL2 distribution: #{config.distribution_name}"
+
+          # Check if distribution already exists
+          if driver.state != :not_created
+            raise Errors::DistributionAlreadyExists,
+                  name: config.distribution_name
+          end
+
+          # Get the box path (assuming it's a tar.gz)
+          box_path = machine.box.directory.join("box.tar.gz")
+          unless File.exist?(box_path)
+            raise Vagrant::Errors::BoxNotFound,
+                  name: machine.box.name,
+                  provider: machine.provider_name
+          end
+
+          # Create the distribution
+          driver.create(box_path)
+
+          # Set the machine ID
+          machine.id = config.distribution_name
+
+          env[:ui].info "WSL2 distribution created successfully"
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-wsl2-provider/action/create.rb
+++ b/lib/vagrant-wsl2-provider/action/create.rb
@@ -1,4 +1,5 @@
 require "vagrant/action/builder"
+require "fileutils"
 
 module VagrantPlugins
   module WSL2
@@ -21,16 +22,52 @@ module VagrantPlugins
                   name: config.distribution_name
           end
 
-          # Get the box path (assuming it's a tar.gz)
-          box_path = machine.box.directory.join("box.tar.gz")
-          unless File.exist?(box_path)
-            raise Vagrant::Errors::BoxNotFound,
-                  name: machine.box.name,
-                  provider: machine.provider_name
+          # Use the box name as WSL distribution name from Microsoft Store
+          box_name = machine.config.vm.box
+          clean_base_name = "#{box_name}-vagrant-base"
+          cache_dir = get_cache_directory
+
+          env[:ui].info "Using WSL distribution: #{box_name}"
+
+          # Check if the distribution is available online
+          unless wsl_distribution_available?(box_name)
+            raise Errors::WSLDistributionNotFound,
+                  name: box_name
           end
 
-          # Create the distribution
-          driver.create(box_path)
+          # Check if we have a clean cached version
+          cached_tar_path = File.join(cache_dir, "#{clean_base_name}.tar")
+
+          unless File.exist?(cached_tar_path)
+            # Check if the original distribution already exists (dirty)
+            if wsl_distribution_installed?(box_name)
+              raise Errors::DirtyDistributionExists,
+                    name: box_name,
+                    clean_name: clean_base_name,
+                    cache_path: cache_dir
+            end
+
+            # Create clean base distribution
+            env[:ui].info "Creating clean base distribution: #{clean_base_name}"
+            create_clean_base_distribution(env, box_name, clean_base_name, cached_tar_path, cache_dir, driver)
+          end
+
+          # Create project-specific distribution from clean base
+          env[:ui].info "Creating project-specific distribution: #{config.distribution_name}"
+          create_project_distribution_from_cache(env, cached_tar_path, config.distribution_name, driver)
+
+          # Set up vagrant user in the new distribution
+          env[:ui].info "Setting up vagrant user and environment"
+          setup_vagrant_user(env, config.distribution_name)
+
+          # Set the project distribution as default only if cache is currently default
+          current_default = get_current_default_distribution
+          if current_default == clean_base_name
+            env[:ui].info "Setting project distribution as default (was cache)"
+            Vagrant::Util::Subprocess.execute("wsl", "--set-default", config.distribution_name)
+          else
+            env[:ui].info "Keeping existing default distribution: #{current_default}"
+          end
 
           # Set the machine ID
           machine.id = config.distribution_name
@@ -38,6 +75,223 @@ module VagrantPlugins
           env[:ui].info "WSL2 distribution created successfully"
 
           @app.call(env)
+        end
+
+        private
+
+        def wsl_distribution_available?(name)
+          result = Vagrant::Util::Subprocess.execute("wsl", "--list", "--online")
+          return false if result.exit_code != 0
+
+          # Handle potential encoding issues - WSL output is UTF-16LE on Windows
+          output = result.stdout.force_encoding('UTF-16LE').encode('UTF-8', invalid: :replace, undef: :replace)
+
+          # Find the line with NAME header and start parsing from the next line
+          lines = output.lines.map(&:strip)
+          name_header_index = lines.find_index { |line| line.start_with?("NAME") }
+
+          return false unless name_header_index
+
+          # Parse lines after the NAME header
+          lines[(name_header_index + 1)..-1].any? do |line|
+            # Skip empty lines
+            next if line.empty?
+
+            # Extract the first word (distribution name) before whitespace
+            distro_name = line.split(/\s+/).first
+            distro_name == name
+          end
+        end
+
+        def wsl_distribution_installed?(name)
+          result = Vagrant::Util::Subprocess.execute("wsl", "--list", "--quiet")
+
+          # If no distributions exist, wsl --list returns non-zero exit code
+          # This is expected and not an error
+          return false if result.exit_code != 0
+
+          # Handle UTF-16LE encoding from WSL on Windows
+          output = result.stdout.force_encoding('UTF-16LE').encode('UTF-8', invalid: :replace, undef: :replace)
+
+          # Check if the distribution name appears in the output
+          output.lines.any? { |line| line.strip == name }
+        rescue
+          # If any error occurs, assume distribution is not installed
+          false
+        end
+
+        def install_wsl_distribution(name, driver)
+          # Use proper non-interactive WSL installation
+          success = system("wsl", "--install", "--distribution", name, "--no-launch")
+          exit_code = success ? 0 : $?.exitstatus
+
+          case exit_code
+          when 0
+            # Installation command succeeded - wait and verify
+            wait_for_distribution_installation(name)
+          when 1
+            raise Errors::WSLInstallFailed,
+                  name: name,
+                  stderr: "General WSL installation error. Check internet connection and Windows Store access."
+          when 2
+            raise Errors::WSLInstallFailed,
+                  name: name,
+                  stderr: "Invalid distribution name or parameters."
+          when 3221225485
+            raise Errors::WSLInstallFailed,
+                  name: name,
+                  stderr: "WSL installation requires a system restart to complete."
+          when 3221225506
+            raise Errors::WSLInstallFailed,
+                  name: name,
+                  stderr: "WSL feature is not enabled. Enable WSL in Windows Features."
+          else
+            raise Errors::WSLInstallFailed,
+                  name: name,
+                  stderr: "Unknown installation error (exit code: #{exit_code})"
+          end
+        end
+
+        def wait_for_distribution_installation(name, timeout = 30)
+          start_time = Time.now
+
+          # Give it a moment for the distribution to appear
+          sleep 3
+
+          # Check if distribution was created
+          if wsl_distribution_installed?(name)
+            return true
+          end
+
+          # If not found immediately, wait a bit more and check again
+          loop do
+            sleep 2
+            if wsl_distribution_installed?(name)
+              return true
+            end
+
+            if Time.now - start_time > timeout
+              raise Errors::WSLInstallFailed,
+                    name: name,
+                    stderr: "Distribution '#{name}' not found after installation completed. Check if installation was successful."
+            end
+          end
+        end
+
+        def get_cache_directory
+          cache_dir = File.expand_path("~/.vagrant.d/wsl2-cache")
+          FileUtils.mkdir_p(cache_dir) unless File.exist?(cache_dir)
+          cache_dir
+        end
+
+        def create_clean_base_distribution(env, box_name, clean_base_name, cached_tar_path, cache_dir, driver)
+          # Install fresh distribution
+          env[:ui].info "Installing fresh WSL distribution: #{box_name}"
+          install_wsl_distribution(box_name, driver)
+
+          # Export to cache
+          env[:ui].info "Exporting clean distribution to cache: #{cached_tar_path}"
+          begin
+            driver.execute_command("wsl", "--export", box_name, cached_tar_path)
+          rescue Errors::WSLCommandFailed => e
+            raise Errors::WSLExportFailed,
+                  name: box_name,
+                  stderr: e.message
+          end
+
+          # Remove the original to prevent contamination
+          env[:ui].info "Removing original distribution to prevent contamination"
+          Vagrant::Util::Subprocess.execute("wsl", "--unregister", box_name)
+
+        end
+
+        def get_current_default_distribution
+          result = Vagrant::Util::Subprocess.execute("wsl", "--list", "--quiet")
+          return nil if result.exit_code != 0
+
+          # Handle UTF-16LE encoding from WSL on Windows
+          output = result.stdout.force_encoding('UTF-16LE').encode('UTF-8', invalid: :replace, undef: :replace)
+
+          # The first line is the default distribution
+          output.lines.first&.strip
+        end
+
+        def setup_vagrant_user(env, distribution_name)
+          # Create vagrant user with home directory
+          run_in_distribution(env, distribution_name, [
+            "useradd -m -s /bin/bash vagrant || true",  # Allow if user exists
+            "echo 'vagrant:vagrant' | chpasswd",
+            "usermod -aG sudo vagrant 2>/dev/null || usermod -aG wheel vagrant 2>/dev/null || true"
+          ])
+
+          # Set up sudo without password
+          run_in_distribution(env, distribution_name, [
+            "echo 'vagrant ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/vagrant",
+            "chmod 440 /etc/sudoers.d/vagrant"
+          ])
+
+          # Set up home directory permissions
+          run_in_distribution(env, distribution_name, [
+            "chown vagrant:vagrant /home/vagrant",
+            "chmod 755 /home/vagrant"
+          ])
+
+          # Set up SSH directory for future use
+          run_in_distribution(env, distribution_name, [
+            "mkdir -p /home/vagrant/.ssh",
+            "chmod 700 /home/vagrant/.ssh",
+            "chown vagrant:vagrant /home/vagrant/.ssh"
+          ])
+
+          # Copy skeleton files
+          run_in_distribution(env, distribution_name, [
+            "cp /etc/skel/.bashrc /home/vagrant/ 2>/dev/null || true",
+            "cp /etc/skel/.profile /home/vagrant/ 2>/dev/null || true",
+            "chown vagrant:vagrant /home/vagrant/.bashrc /home/vagrant/.profile 2>/dev/null || true"
+          ])
+        end
+
+        def run_in_distribution(env, distribution_name, commands)
+          commands.each do |command|
+            result = Vagrant::Util::Subprocess.execute(
+              "wsl", "-d", distribution_name, "-u", "root", "--", "bash", "-c", command
+            )
+
+            # Don't fail on non-critical setup commands
+            if result.exit_code != 0
+              env[:ui].warn "Command failed (continuing): #{command}"
+              env[:ui].error "#{result.stderr}" unless result.stderr.empty?
+            end
+          end
+        end
+
+        def create_project_distribution_from_cache(env, cached_tar_path, target_name, driver)
+          # Import project-specific distribution directly from cache
+          env[:ui].info "Creating WSL2 distribution '#{target_name}' from cached image: #{cached_tar_path}"
+          driver.create(cached_tar_path)
+        end
+
+        def create_project_distribution(source_name, target_name, driver)
+          # Create temporary export path
+          temp_export = File.join(Dir.tmpdir, "#{target_name}-export.tar")
+
+          begin
+            # Export the base distribution
+            begin
+              driver.execute_command("wsl", "--export", source_name, temp_export)
+            rescue Errors::WSLCommandFailed => e
+              raise Errors::WSLExportFailed,
+                    name: source_name,
+                    stderr: e.message
+            end
+
+            # Import as project-specific distribution
+            driver.create(temp_export)
+
+          ensure
+            # Clean up temporary file
+            File.delete(temp_export) if File.exist?(temp_export)
+          end
         end
       end
     end

--- a/lib/vagrant-wsl2-provider/action/create.rb
+++ b/lib/vagrant-wsl2-provider/action/create.rb
@@ -179,7 +179,8 @@ module VagrantPlugins
         end
 
         def get_cache_directory
-          cache_dir = File.expand_path("~/.vagrant.d/wsl2-cache")
+          # Use Vagrant's data directory instead of relying on HOME environment variable
+          cache_dir = File.join(Vagrant.user_data_path, "wsl2-cache")
           FileUtils.mkdir_p(cache_dir) unless File.exist?(cache_dir)
           cache_dir
         end

--- a/lib/vagrant-wsl2-provider/action/destroy.rb
+++ b/lib/vagrant-wsl2-provider/action/destroy.rb
@@ -1,0 +1,38 @@
+module VagrantPlugins
+  module WSL2
+    module Action
+      class Destroy
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          machine = env[:machine]
+          driver = env[:wsl2_driver]
+
+          if machine.id
+            env[:ui].info "Destroying WSL2 distribution: #{machine.id}"
+
+            # Halt the distribution first if it's running
+            if driver.state == :running
+              env[:ui].info "Stopping WSL2 distribution before destroy"
+              driver.halt
+            end
+
+            # Destroy the distribution
+            driver.destroy
+
+            # Clear the machine ID
+            machine.id = nil
+
+            env[:ui].info "WSL2 distribution destroyed"
+          else
+            env[:ui].info "WSL2 distribution not created, nothing to destroy"
+          end
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-wsl2-provider/action/halt.rb
+++ b/lib/vagrant-wsl2-provider/action/halt.rb
@@ -1,0 +1,33 @@
+module VagrantPlugins
+  module WSL2
+    module Action
+      class Halt
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          machine = env[:machine]
+          driver = env[:wsl2_driver]
+
+          if machine.id
+            case driver.state
+            when :stopped
+              env[:ui].info "WSL2 distribution is already stopped"
+            when :running
+              env[:ui].info "Stopping WSL2 distribution: #{machine.id}"
+              driver.halt
+              env[:ui].info "WSL2 distribution stopped"
+            else
+              env[:ui].warn "WSL2 distribution is in unknown state"
+            end
+          else
+            raise Errors::DistributionNotFound
+          end
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-wsl2-provider/action/prepare_environment.rb
+++ b/lib/vagrant-wsl2-provider/action/prepare_environment.rb
@@ -1,0 +1,23 @@
+module VagrantPlugins
+  module WSL2
+    module Action
+      class PrepareEnvironment
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          # Set up the WSL2 driver in the environment
+          env[:wsl2_driver] = Driver.new(env[:machine])
+
+          # Ensure we're on Windows
+          unless Vagrant::Util::Platform.windows?
+            raise Errors::WindowsRequired
+          end
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-wsl2-provider/action/share_folders.rb
+++ b/lib/vagrant-wsl2-provider/action/share_folders.rb
@@ -1,0 +1,88 @@
+require "vagrant"
+
+module VagrantPlugins
+  module WSL2
+    module Action
+      class ShareFolders
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          # Set up shared folders for WSL2 BEFORE calling next action
+          env[:ui].info "Setting up shared folders for WSL2 distribution"
+          setup_shared_folders(env)
+
+          @app.call(env)
+        end
+
+        private
+
+        def setup_shared_folders(env)
+          machine = env[:machine]
+          distribution_name = machine.id
+
+          return if distribution_name.nil?
+
+          # Get shared folders configuration
+          shared_folders = {}
+
+          # Add default /vagrant folder (always enabled unless explicitly disabled in synced_folders)
+          unless machine.config.vm.synced_folders["/vagrant"] && machine.config.vm.synced_folders["/vagrant"][:disabled]
+            shared_folders["/vagrant"] = {
+              hostpath: machine.env.cwd.to_s,
+              guestpath: "/vagrant",
+              disabled: false
+            }
+          end
+
+          # Add user-defined shared folders
+          machine.config.vm.synced_folders.each do |id, data|
+            next if data[:disabled]
+            shared_folders[data[:guestpath]] = data
+          end
+
+          # Create shared folders in WSL2
+          shared_folders.each do |guestpath, data|
+            create_shared_folder(env, distribution_name, data[:hostpath], guestpath)
+          end
+        end
+
+        def create_shared_folder(env, distribution_name, hostpath, guestpath)
+          # Convert Windows path to WSL2 path
+          # Handle both full paths and relative paths
+          if hostpath.match(/^[A-Z]:[\\\/]/)
+            # Full Windows path
+            wsl_hostpath = hostpath.gsub("\\", "/").gsub(/^([A-Z]):/, '/mnt/\1').downcase
+          else
+            # Relative path - convert to absolute first
+            absolute_path = File.expand_path(hostpath)
+            wsl_hostpath = absolute_path.gsub("\\", "/").gsub(/^([A-Z]):/, '/mnt/\1').downcase
+          end
+
+          env[:ui].info "Creating shared folder: #{hostpath} -> #{guestpath}"
+
+          # Create the shared folder using symlink
+          commands = [
+            "mkdir -p #{File.dirname(guestpath)}",
+            "rm -rf #{guestpath}",
+            "ln -sf #{wsl_hostpath} #{guestpath}",
+            "chown -h vagrant:vagrant #{guestpath}"
+          ]
+
+          commands.each do |command|
+            result = Vagrant::Util::Subprocess.execute(
+              "wsl", "-d", distribution_name, "-u", "root", "--",
+              "bash", "-c", command
+            )
+
+            if result.exit_code != 0
+              raise Vagrant::Errors::VagrantError,
+                    "Failed to create shared folder: #{command}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-wsl2-provider/action/start.rb
+++ b/lib/vagrant-wsl2-provider/action/start.rb
@@ -1,0 +1,33 @@
+module VagrantPlugins
+  module WSL2
+    module Action
+      class Start
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          machine = env[:machine]
+          driver = env[:wsl2_driver]
+
+          if machine.id
+            case driver.state
+            when :running
+              env[:ui].info "WSL2 distribution is already running"
+            when :stopped
+              env[:ui].info "Starting WSL2 distribution: #{machine.id}"
+              driver.start
+              env[:ui].info "WSL2 distribution started"
+            else
+              env[:ui].warn "WSL2 distribution is in unknown state"
+            end
+          else
+            raise Errors::DistributionNotFound
+          end
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-wsl2-provider/action/wsl_shell.rb
+++ b/lib/vagrant-wsl2-provider/action/wsl_shell.rb
@@ -1,0 +1,27 @@
+module VagrantPlugins
+  module WSL2
+    module Action
+      class WSLShell
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          machine = env[:machine]
+
+          if machine.id.nil?
+            raise Errors::DistributionNotFound
+          end
+
+          # Start an interactive shell in the WSL2 distribution as vagrant user
+          env[:ui].info "Connecting to WSL2 distribution: #{machine.id}"
+
+          # Change to vagrant user's home directory and start bash
+          system("wsl", "-d", machine.id, "-u", "vagrant", "--", "bash", "-l")
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-wsl2-provider/cap/shell_expand_guest_path.rb
+++ b/lib/vagrant-wsl2-provider/cap/shell_expand_guest_path.rb
@@ -1,0 +1,22 @@
+require "vagrant"
+
+module VagrantPlugins
+  module WSL2
+    module Cap
+      class ShellExpandGuestPath
+        def self.shell_expand_guest_path(machine, path)
+          # Use the WSL2 communicator's shell_expand_guest_path method
+          comm = machine.communicate
+
+          # Call the communicator method directly
+          if comm.respond_to?(:shell_expand_guest_path)
+            return comm.shell_expand_guest_path(path)
+          end
+
+          # Fallback: return original path
+          path
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-wsl2-provider/communicator.rb
+++ b/lib/vagrant-wsl2-provider/communicator.rb
@@ -1,0 +1,199 @@
+require "vagrant"
+
+module VagrantPlugins
+  module WSL2
+    class Communicator < Vagrant.plugin("2", :communicator)
+      def self.match?(machine)
+        # Use this communicator for WSL2 provider
+        machine.provider_name == :wsl2
+      end
+
+      def initialize(machine)
+        @machine = machine
+        @logger = Log4r::Logger.new("vagrant::communication::wsl2")
+      end
+
+      def ready?
+        # WSL2 distribution is always ready if it exists
+        @machine.state.id != :not_created
+      end
+
+      def execute(command, opts = {})
+        # Execute command in WSL2 distribution as vagrant user
+        distribution_name = @machine.id
+        return 1 if distribution_name.nil?
+
+        # puts "*** WSL2 EXECUTE: #{command} ***"  # Debug all commands
+        @logger.debug("Executing command in WSL2: #{command}")
+        # puts "DEBUG: Executing WSL2 command: #{command}" if ENV['VAGRANT_DEBUG']
+
+        # Set up IO for real-time output
+        io_stdin = opts[:stdin] if opts[:stdin]
+        io_stdout = opts[:stdout] if opts[:stdout]
+        io_stderr = opts[:stderr] if opts[:stderr]
+
+        # Encode command using base64 to avoid shell escaping issues
+        encoded_command = encode_command(command)
+
+        result = Vagrant::Util::Subprocess.execute(
+          "wsl", "-d", distribution_name, "-u", "vagrant", "--",
+          "bash", "-l", "-c", encoded_command,
+          :notify => [:stdin, :stdout, :stderr]
+        ) do |type, data|
+          case type
+          when :stdout
+            io_stdout.write(data) if io_stdout
+            puts data if !io_stdout
+          when :stderr
+            io_stderr.write(data) if io_stderr
+            $stderr.puts data if !io_stderr
+          end
+        end
+
+        # puts "DEBUG: WSL2 command result: exit_code=#{result.exit_code}" if ENV['VAGRANT_DEBUG']
+
+        # Handle output if needed
+        if opts[:error_check] != false && result.exit_code != 0
+          raise Vagrant::Errors::VagrantError,
+                "Command failed with exit code #{result.exit_code}: #{command}"
+        end
+
+        result.exit_code
+      end
+
+      def sudo(command, opts = {})
+        # Use sudo in WSL2 distribution
+        # puts "*** WSL2 SUDO COMMAND: sudo #{command} ***"  # Debug sudo commands
+        @logger.debug("Executing sudo command in WSL2: sudo #{command}")
+        execute("sudo #{command}", opts)
+      end
+
+      def download(from, to = nil)
+        @logger.warn("Download not implemented for WSL2 communicator")
+      end
+
+      def upload(from, to)
+        # Upload file to WSL2 distribution
+        distribution_name = @machine.id
+        return if distribution_name.nil?
+
+        # puts "*** WSL2 UPLOAD: #{from} -> #{to} ***"  # Debug
+        @logger.debug("Uploading #{from} to #{to} in WSL2")
+
+        # Read local file and write to WSL2
+        content = File.read(from)
+        # puts "*** WSL2 UPLOAD CONTENT LENGTH: #{content.length} ***"
+
+        # Create directory if needed
+        dir = File.dirname(to)
+        execute("mkdir -p #{dir}")
+
+        # Write file content using base64 encoding to avoid shell escaping issues
+        require 'base64'
+        encoded_content = Base64.strict_encode64(content)
+        # Direct base64 command - no need for encode_command here as it's already base64
+        result = Vagrant::Util::Subprocess.execute(
+          "wsl", "-d", distribution_name, "-u", "vagrant", "--",
+          "bash", "-c", "echo '#{encoded_content}' | base64 -d > #{to}"
+        )
+
+        # puts "*** WSL2 UPLOAD RESULT: #{result.exit_code} ***"
+
+        if result.exit_code != 0
+          # puts "*** WSL2 UPLOAD ERROR: #{result.stderr} ***"
+          raise Vagrant::Errors::VagrantError,
+                "Failed to upload file to WSL2: #{result.stderr}"
+        end
+
+        # Make uploaded file executable if it's a script
+        if to.include?('/tmp/vagrant-shell')
+          execute("chmod +x #{to}")
+        end
+      end
+
+      def test(command, opts = {})
+        # Test command (return true/false)
+        result = execute(command, opts.merge(error_check: false))
+        result == 0
+      end
+
+  def shell_expand_guest_path(path)
+    # WSL2-specific shell path expansion implementation
+    distribution_name = @machine.id
+    return path if distribution_name.nil?
+
+    @logger.debug("Expanding shell path: #{path}")
+
+    # Escape spaces and use printf for proper shell expansion
+    escaped_path = path.gsub(/ /, '\\ ')
+    real_path = nil
+
+    # Execute printf command to expand the path
+    result = Vagrant::Util::Subprocess.execute(
+      "wsl", "-d", distribution_name, "-u", "vagrant", "--",
+      "bash", "-c", "printf #{escaped_path}"
+    )
+
+    if result.exit_code == 0 && !result.stdout.strip.empty?
+      expanded_path = result.stdout.strip
+      @logger.debug("Path expanded from #{path} to #{expanded_path}")
+      expanded_path
+    else
+      @logger.debug("Path expansion failed, returning original path: #{path}")
+      path
+    end
+  end
+      
+
+      private
+
+      def encode_command(command)
+        # Use base64 encoding to completely avoid shell escaping issues
+        # This is much more reliable than trying to escape complex shell commands
+
+        # Fix multiline sudo commands by ensuring all lines have sudo
+        fixed_command = fix_multiline_sudo(command)
+
+        require 'base64'
+        encoded = Base64.strict_encode64(fixed_command)
+        result_cmd = "echo '#{encoded}' | base64 -d | bash"
+        # puts "*** WSL2 BASE64 ENCODING: #{command.length} chars -> #{encoded.length} chars ***"
+        result_cmd
+      end
+
+      def fix_multiline_sudo(command)
+        # Fix commands that start with sudo but have multiline continuation OR pipe operations
+        if command.strip.start_with?('sudo')
+          # Handle multiline commands
+          if command.include?("\n")
+            lines = command.split("\n")
+            first_line = lines[0].strip
+
+            if first_line == 'sudo' && lines.length > 1
+              # Combine all lines into a single sudo command, preserving && structure
+              remaining_lines = lines[1..-1].join(' ').strip
+
+              # For commands with &&, wrap the entire command sequence in sudo bash -c
+              if remaining_lines.include?('&&')
+                "sudo bash -c '#{remaining_lines}'"
+              else
+                "sudo #{remaining_lines}"
+              end
+            else
+              command
+            end
+          # Handle pipe operations that need sudo for the entire pipeline
+          elsif command.include?('|') && command.include?('bash')
+            # For commands like "sudo curl ... | bash", wrap entire pipeline in sudo bash -c
+            command_without_sudo = command.sub(/^sudo\s+/, '')
+            "sudo bash -c '#{command_without_sudo}'"
+          else
+            command
+          end
+        else
+          command
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-wsl2-provider/config.rb
+++ b/lib/vagrant-wsl2-provider/config.rb
@@ -1,0 +1,74 @@
+require "vagrant"
+
+module VagrantPlugins
+  module WSL2
+    class Config < Vagrant.plugin("2", :config)
+      # WSL2 distribution name
+      attr_accessor :distribution_name
+
+      # WSL2 version (1 or 2)
+      attr_accessor :version
+
+      # Memory limit in MB
+      attr_accessor :memory
+
+      # CPU count
+      attr_accessor :cpus
+
+      # Custom kernel parameters
+      attr_accessor :kernel_command_line
+
+      # Swap size in MB
+      attr_accessor :swap
+
+      # Enable GUI support (WSLg)
+      attr_accessor :gui_support
+
+      def initialize
+        @distribution_name = UNSET_VALUE
+        @version = UNSET_VALUE
+        @memory = UNSET_VALUE
+        @cpus = UNSET_VALUE
+        @kernel_command_line = UNSET_VALUE
+        @swap = UNSET_VALUE
+        @gui_support = UNSET_VALUE
+      end
+
+      def finalize!
+        @distribution_name = "vagrant-#{Time.now.to_i}" if @distribution_name == UNSET_VALUE
+        @version = 2 if @version == UNSET_VALUE
+        @memory = 4096 if @memory == UNSET_VALUE
+        @cpus = 2 if @cpus == UNSET_VALUE
+        @kernel_command_line = "" if @kernel_command_line == UNSET_VALUE
+        @swap = 1024 if @swap == UNSET_VALUE
+        @gui_support = false if @gui_support == UNSET_VALUE
+      end
+
+      def validate(machine)
+        errors = _detected_errors
+
+        # Validate distribution name
+        if @distribution_name.to_s.strip.empty?
+          errors << "Distribution name cannot be empty"
+        end
+
+        # Validate WSL version
+        unless [1, 2].include?(@version)
+          errors << "WSL version must be 1 or 2"
+        end
+
+        # Validate memory
+        if @memory && (@memory < 512 || @memory > 32768)
+          errors << "Memory must be between 512MB and 32GB"
+        end
+
+        # Validate CPU count
+        if @cpus && (@cpus < 1 || @cpus > 32)
+          errors << "CPU count must be between 1 and 32"
+        end
+
+        { "WSL2 Provider" => errors }
+      end
+    end
+  end
+end

--- a/lib/vagrant-wsl2-provider/driver.rb
+++ b/lib/vagrant-wsl2-provider/driver.rb
@@ -1,0 +1,108 @@
+require "vagrant/util/subprocess"
+
+module VagrantPlugins
+  module WSL2
+    class Driver
+      def initialize(machine)
+        @machine = machine
+        @config = machine.provider_config
+      end
+
+      # Get the current state of the WSL2 distribution
+      def state
+        result = execute("wsl", "--list", "--verbose")
+
+        distributions = parse_wsl_list_output(result.stdout)
+        distro = distributions.find { |d| d[:name] == @config.distribution_name }
+
+        return :not_created unless distro
+
+        case distro[:state]
+        when "Running"
+          :running
+        when "Stopped"
+          :stopped
+        else
+          :unknown
+        end
+      end
+
+      # Create a new WSL2 distribution
+      def create(box_path)
+        # Import the distribution from a tar.gz file
+        execute("wsl", "--import", @config.distribution_name,
+                distribution_path, box_path, "--version", @config.version.to_s)
+      end
+
+      # Start the WSL2 distribution
+      def start
+        execute("wsl", "--distribution", @config.distribution_name, "--exec", "true")
+      end
+
+      # Stop the WSL2 distribution
+      def halt
+        execute("wsl", "--terminate", @config.distribution_name)
+      end
+
+      # Destroy the WSL2 distribution
+      def destroy
+        execute("wsl", "--unregister", @config.distribution_name)
+
+        # Clean up distribution files
+        dist_path = distribution_path
+        FileUtils.rm_rf(dist_path) if File.exist?(dist_path)
+      end
+
+      # Execute a command in the WSL2 distribution
+      def execute_in_wsl(*args)
+        execute("wsl", "--distribution", @config.distribution_name, *args)
+      end
+
+      private
+
+      # Execute a Windows command
+      def execute(*args)
+        result = Vagrant::Util::Subprocess.execute(*args)
+
+        if result.exit_code != 0
+          raise Errors::WSLCommandFailed,
+                command: args.join(" "),
+                stderr: result.stderr
+        end
+
+        result
+      end
+
+      # Parse the output of 'wsl --list --verbose'
+      def parse_wsl_list_output(output)
+        distributions = []
+
+        # Skip header lines and parse each distribution
+        lines = output.split("\n")[1..-1] || []
+
+        lines.each do |line|
+          next if line.strip.empty?
+
+          # Parse line format: "  NAME    STATE    VERSION"
+          parts = line.strip.split(/\s+/)
+          next if parts.length < 3
+
+          distributions << {
+            name: parts[0].gsub(/\*/, "").strip,
+            state: parts[1],
+            version: parts[2]
+          }
+        end
+
+        distributions
+      end
+
+      # Get the path where this distribution should be stored
+      def distribution_path
+        @machine.data_dir.join("wsl2_distribution").to_s
+      end
+    end
+  end
+end
+
+require_relative "errors"

--- a/lib/vagrant-wsl2-provider/errors.rb
+++ b/lib/vagrant-wsl2-provider/errors.rb
@@ -26,6 +26,26 @@ module VagrantPlugins
       class DistributionAlreadyExists < WSL2Error
         error_key(:distribution_already_exists)
       end
+
+      class WSLDistributionNotFound < WSL2Error
+        error_key(:wsl_distribution_not_found)
+      end
+
+      class WSLInstallFailed < WSL2Error
+        error_key(:wsl_install_failed)
+      end
+
+      class WSLExportFailed < WSL2Error
+        error_key(:wsl_export_failed)
+      end
+
+      class WSLImportFailed < WSL2Error
+        error_key(:wsl_import_failed)
+      end
+
+      class DirtyDistributionExists < WSL2Error
+        error_key(:dirty_distribution_exists)
+      end
     end
   end
 end

--- a/lib/vagrant-wsl2-provider/errors.rb
+++ b/lib/vagrant-wsl2-provider/errors.rb
@@ -1,0 +1,31 @@
+require "vagrant"
+
+module VagrantPlugins
+  module WSL2
+    module Errors
+      class WSL2Error < Vagrant::Errors::VagrantError
+        error_namespace("vagrant_wsl2.errors")
+      end
+
+      class WindowsRequired < WSL2Error
+        error_key(:windows_required)
+      end
+
+      class WSLNotInstalled < WSL2Error
+        error_key(:wsl_not_installed)
+      end
+
+      class WSLCommandFailed < WSL2Error
+        error_key(:wsl_command_failed)
+      end
+
+      class DistributionNotFound < WSL2Error
+        error_key(:distribution_not_found)
+      end
+
+      class DistributionAlreadyExists < WSL2Error
+        error_key(:distribution_already_exists)
+      end
+    end
+  end
+end

--- a/lib/vagrant-wsl2-provider/plugin.rb
+++ b/lib/vagrant-wsl2-provider/plugin.rb
@@ -1,0 +1,32 @@
+require "vagrant"
+
+module VagrantPlugins
+  module WSL2
+    def self.source_root
+      @source_root ||= Pathname.new(File.expand_path("../../", __FILE__))
+    end
+
+    class Plugin < Vagrant.plugin("2")
+      name "WSL2 Provider"
+      description "Vagrant provider plugin for managing WSL2 distributions"
+
+      # Load locales
+      def self.setup_i18n
+        locale_path = File.expand_path("../../../locales/en/vagrant_wsl2.yml", __FILE__)
+        I18n.load_path << locale_path if File.exist?(locale_path)
+        I18n.reload!
+      end
+
+      provider "wsl2" do
+        setup_i18n
+        require_relative "provider"
+        Provider
+      end
+
+      config "wsl2", :provider do
+        require_relative "config"
+        Config
+      end
+    end
+  end
+end

--- a/lib/vagrant-wsl2-provider/plugin.rb
+++ b/lib/vagrant-wsl2-provider/plugin.rb
@@ -27,6 +27,18 @@ module VagrantPlugins
         require_relative "config"
         Config
       end
+
+      communicator "wsl2" do
+        require_relative "communicator"
+        Communicator
+      end
+
+      # Universal guest capability for shell path expansion
+      guest_capability "linux", "shell_expand_guest_path" do
+        require_relative "cap/shell_expand_guest_path"
+        Cap::ShellExpandGuestPath
+      end
+
     end
   end
 end

--- a/lib/vagrant-wsl2-provider/provider.rb
+++ b/lib/vagrant-wsl2-provider/provider.rb
@@ -1,0 +1,71 @@
+require "vagrant"
+require "vagrant/util/platform"
+
+module VagrantPlugins
+  module WSL2
+    class Provider < Vagrant.plugin("2", :provider)
+      def initialize(machine)
+        @machine = machine
+        @driver = Driver.new(@machine)
+      end
+
+      # Returns the SSH info for accessing the machine
+      def ssh_info
+        return nil if state.id != :running
+
+        {
+          host: "localhost",
+          port: 22,
+          username: "vagrant",
+          private_key_path: @machine.data_dir.join("private_key").to_s,
+        }
+      end
+
+      # Returns the current state of the machine
+      def state
+        state_id = nil
+        state_id = @driver.state if @driver
+
+        state_id = :not_created if state_id.nil?
+
+        short = state_id.to_s.gsub("_", " ")
+        long = I18n.t("vagrant_wsl2.states.#{state_id}")
+
+        Vagrant::MachineState.new(state_id, short, long)
+      end
+
+      # Returns a human-friendly string version of this provider
+      def to_s
+        id = @machine.id || "new"
+        "WSL2 (#{id})"
+      end
+
+      # This method is called if the underlying machine ID changes
+      def machine_id_changed
+        # Nothing to do
+      end
+
+      # Provider capabilities
+      def capability(cap_name)
+        case cap_name
+        when :halt
+          @driver.halt
+        when :destroy
+          @driver.destroy
+        else
+          super
+        end
+      end
+
+      private
+
+      def ensure_windows_platform!
+        unless Vagrant::Util::Platform.windows?
+          raise Errors::WindowsRequired
+        end
+      end
+    end
+  end
+end
+
+require_relative "driver"

--- a/lib/vagrant-wsl2-provider/provider.rb
+++ b/lib/vagrant-wsl2-provider/provider.rb
@@ -3,21 +3,46 @@ require "vagrant/util/platform"
 
 module VagrantPlugins
   module WSL2
+    module Action
+      # Import our custom actions
+      autoload :Create, File.expand_path("../action/create", __FILE__)
+      autoload :Destroy, File.expand_path("../action/destroy", __FILE__)
+      autoload :Halt, File.expand_path("../action/halt", __FILE__)
+      autoload :Start, File.expand_path("../action/start", __FILE__)
+      autoload :PrepareEnvironment, File.expand_path("../action/prepare_environment", __FILE__)
+      autoload :WSLShell, File.expand_path("../action/wsl_shell", __FILE__)
+      autoload :ShareFolders, File.expand_path("../action/share_folders", __FILE__)
+    end
     class Provider < Vagrant.plugin("2", :provider)
       def initialize(machine)
         @machine = machine
         @driver = Driver.new(@machine)
+
+        # Force WSL2 communicator usage
+        @machine.config.vm.communicator = :wsl2
+      end
+
+      # Define action hooks for Vagrant commands
+      def action(name)
+        return action_up if name == :up
+        return action_halt if name == :halt
+        return action_destroy if name == :destroy
+        return action_ssh if name == :ssh
+        return action_provision if name == :provision
+        return action_reload if name == :reload
+        nil
       end
 
       # Returns the SSH info for accessing the machine
       def ssh_info
-        return nil if state.id != :running
+        return nil if state.id == :not_created
 
+        # Return special marker to indicate WSL-native connection
         {
-          host: "localhost",
-          port: 22,
+          host: "wsl-native",
           username: "vagrant",
-          private_key_path: @machine.data_dir.join("private_key").to_s,
+          wsl_distribution: @machine.id,
+          ready: true
         }
       end
 
@@ -62,6 +87,109 @@ module VagrantPlugins
       def ensure_windows_platform!
         unless Vagrant::Util::Platform.windows?
           raise Errors::WindowsRequired
+        end
+      end
+
+      # Define action middleware for 'vagrant up'
+      def action_up
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use Vagrant::Action::Builtin::ConfigValidate
+          b.use Vagrant::Action::Builtin::Call, Vagrant::Action::Builtin::IsState, :not_created do |env, b2|
+            if env[:result]
+              b2.use Action::PrepareEnvironment
+              b2.use Action::Create
+              b2.use Action::Start
+              b2.use Action::ShareFolders
+              b2.use Vagrant::Action::Builtin::Provision
+            else
+              b2.use Action::PrepareEnvironment
+              b2.use Vagrant::Action::Builtin::Call, Vagrant::Action::Builtin::IsState, :running do |env2, b3|
+                unless env2[:result]
+                  b3.use Action::Start
+                end
+              end
+              b2.use Action::ShareFolders
+              b2.use Vagrant::Action::Builtin::Provision
+            end
+          end
+        end
+      end
+
+      # Define action middleware for 'vagrant halt'
+      def action_halt
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use Vagrant::Action::Builtin::ConfigValidate
+          b.use Vagrant::Action::Builtin::Call, Vagrant::Action::Builtin::IsState, :running do |env, b2|
+            if env[:result]
+              b2.use Action::PrepareEnvironment
+              b2.use Action::Halt
+            end
+          end
+        end
+      end
+
+      # Define action middleware for 'vagrant destroy'
+      def action_destroy
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use Vagrant::Action::Builtin::ConfigValidate
+          b.use Vagrant::Action::Builtin::Call, Vagrant::Action::Builtin::IsState, :not_created do |env, b2|
+            unless env[:result]
+              b2.use Action::PrepareEnvironment
+              b2.use Action::Destroy
+            end
+          end
+        end
+      end
+
+      # Define action middleware for 'vagrant ssh'
+      def action_ssh
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use Vagrant::Action::Builtin::ConfigValidate
+          b.use Vagrant::Action::Builtin::Call, Vagrant::Action::Builtin::IsState, :running do |env, b2|
+            if env[:result]
+              b2.use Action::PrepareEnvironment
+              b2.use Action::WSLShell
+            else
+              env[:ui].info("Machine is not running, starting it up...")
+              b2.use action_up
+              b2.use Action::WSLShell
+            end
+          end
+        end
+      end
+
+      # Define action middleware for 'vagrant provision'
+      def action_provision
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use Vagrant::Action::Builtin::ConfigValidate
+          b.use Vagrant::Action::Builtin::Call, Vagrant::Action::Builtin::IsState, :running do |env, b2|
+            if env[:result]
+              b2.use Action::PrepareEnvironment
+              b2.use Action::ShareFolders
+              b2.use Vagrant::Action::Builtin::Provision
+            else
+              env[:ui].info("Machine is not running, starting it up...")
+              b2.use action_up
+              b2.use Vagrant::Action::Builtin::Provision
+            end
+          end
+        end
+      end
+
+      # Define action middleware for 'vagrant reload'
+      def action_reload
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use Vagrant::Action::Builtin::ConfigValidate
+          b.use Vagrant::Action::Builtin::Call, Vagrant::Action::Builtin::IsState, :not_created do |env, b2|
+            if env[:result]
+              env[:ui].info("Machine not created, creating...")
+              b2.use action_up
+            else
+              b2.use Action::PrepareEnvironment
+              b2.use Action::Halt
+              b2.use Action::Start
+            end
+          end
         end
       end
     end

--- a/lib/vagrant-wsl2-provider/version.rb
+++ b/lib/vagrant-wsl2-provider/version.rb
@@ -1,0 +1,5 @@
+module VagrantPlugins
+  module WSL2
+    VERSION = "0.1.0"
+  end
+end

--- a/locales/en/vagrant_wsl2.yml
+++ b/locales/en/vagrant_wsl2.yml
@@ -1,0 +1,14 @@
+en:
+  vagrant_wsl2:
+    states:
+      not_created: "The WSL2 distribution is not created"
+      running: "The WSL2 distribution is running"
+      stopped: "The WSL2 distribution is stopped"
+      unknown: "The WSL2 distribution is in an unknown state"
+
+    errors:
+      windows_required: "This provider only works on Windows"
+      wsl_not_installed: "WSL is not installed or not available"
+      wsl_command_failed: "WSL command failed: %{command}\nError: %{stderr}"
+      distribution_not_found: "WSL2 distribution not found"
+      distribution_already_exists: "WSL2 distribution '%{name}' already exists"

--- a/locales/en/vagrant_wsl2.yml
+++ b/locales/en/vagrant_wsl2.yml
@@ -12,3 +12,21 @@ en:
       wsl_command_failed: "WSL command failed: %{command}\nError: %{stderr}"
       distribution_not_found: "WSL2 distribution not found"
       distribution_already_exists: "WSL2 distribution '%{name}' already exists"
+      wsl_distribution_not_found: "WSL distribution '%{name}' is not available. Run 'wsl --list --online' to see available distributions."
+      wsl_install_failed: "Failed to install WSL distribution '%{name}': %{stderr}"
+      wsl_export_failed: "Failed to export WSL distribution '%{name}': %{stderr}"
+      wsl_import_failed: "Failed to import WSL distribution '%{name}': %{stderr}"
+      dirty_distribution_exists: |
+        CRITICAL ERROR: Dirty WSL distribution detected!
+
+        The distribution '%{name}' already exists on your system and may contain modifications
+        that would contaminate your Vagrant environment.
+
+        To fix this, either:
+        1. Remove the existing distribution: wsl --unregister %{name}
+        2. Or manually create a clean base in cache directory: %{cache_path}
+
+        Clean base distribution name: %{clean_name}
+
+        This provider requires clean, reproducible environments and cannot proceed with
+        potentially contaminated distributions.

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -1,7 +1,7 @@
 # Test Vagrantfile for vagrant-wsl2-provider
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "Ubuntu-24.04"
 
   config.vm.provider "wsl2" do |wsl|
     wsl.distribution_name = "vagrant-wsl2-test"
@@ -11,11 +11,72 @@ Vagrant.configure("2") do |config|
     wsl.gui_support = false
   end
 
-  # Test provisioning
+  # Test additional shared folder
+  config.vm.synced_folder "../", "/vagrant-shared"
+
+  # Test shell provisioning
   config.vm.provision "shell", inline: <<-SHELL
+    echo "=== Shell Provisioner Test ==="
     echo "Hello from WSL2 Vagrant provider!"
     whoami
     uname -a
-    echo "Test completed successfully"
+    echo "Shell provisioner completed successfully"
+    echo "shell-test" > /home/vagrant/shell-test.txt
   SHELL
+
+  # Test file provisioner (disabled due to guest detection issues)
+  config.vm.provision "file", source: "test-file.txt", destination: "/home/vagrant/uploaded-file-test.txt"
+  
+  Test ansible_local provisioner
+  config.vm.provision "ansible_local" do |ansible|
+    ansible.playbook = "test-playbook.yml"
+    ansible.verbose = true
+    ansible.install = true
+    ansible.install_mode = :default  # Use apt instead of pip on Ubuntu
+  end
+
+  # Test Chef Solo provisioner
+  # The provioner fails to create a symlink for the cookbooks
+  # *** WSL2 EXECUTE: test -d /tmp/vagrant-chef/9ddb73e3544c15921a3fc2d3e99ba6a1/cookbooks ***
+  # Shared folders that Chef requires are missing on the virtual machine.
+  # This is usually due to configuration changing after already booting the
+  # machine. The fix is to run a `vagrant reload` so that the proper shared
+  # folders will be prepared and mounted on the VM.
+  #
+  # config.vm.provision "chef_solo" do |chef|
+  #   chef.cookbooks_path = "cookbooks"
+  #   chef.add_recipe "test-cookbook::default"
+  #   chef.arguments = "--chef-license accept"  # Accept Chef license
+  #   chef.json = {
+  #     "test" => {
+  #       "message" => "Hello from Chef on WSL2!"
+  #     }
+  #   }
+  # end
+
+  # Test SaltStack provisioner
+  # In version 2.4.1, Vagrant attempted to bootstrap Salt using https://bootstrap.saltproject.io/. 
+  # However, this script has since moved to https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh. 
+  # Because the old site no longer hosts the required script, Vagrant is unable to complete the bootstrap process.
+  # Recommended updating Vagrant to a version that recognises this change (Latest Vagrant Version 2.4.6)—the process should work correctly after upgrading.
+  # config.vm.provision "salt" do |salt|
+  #   salt.masterless = true
+  #   salt.minion_config = "salt/minion"
+  #   salt.run_highstate = true
+  #   salt.install_type = "stable"
+  #   salt.verbose = true
+  # end
+
+  # Show provisioning results
+  config.vm.provision "shell", inline: <<-SHELL
+    echo "=== Provisioning Results ==="
+    echo "Files in /home/vagrant/:"
+    ls -la /home/vagrant/ | grep -E '(test|ansible|chef)'
+
+    echo "=== Shared Folders ==="
+    ls -la /vagrant-shared/
+
+    echo "=== Test Complete ==="
+  SHELL
+
 end

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
   # Test file provisioner (disabled due to guest detection issues)
   config.vm.provision "file", source: "test-file.txt", destination: "/home/vagrant/uploaded-file-test.txt"
   
-  Test ansible_local provisioner
+  # Test ansible_local provisioner
   config.vm.provision "ansible_local" do |ansible|
     ansible.playbook = "test-playbook.yml"
     ansible.verbose = true

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -1,0 +1,21 @@
+# Test Vagrantfile for vagrant-wsl2-provider
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/focal64"
+
+  config.vm.provider "wsl2" do |wsl|
+    wsl.distribution_name = "vagrant-wsl2-test"
+    wsl.version = 2
+    wsl.memory = 2048
+    wsl.cpus = 2
+    wsl.gui_support = false
+  end
+
+  # Test provisioning
+  config.vm.provision "shell", inline: <<-SHELL
+    echo "Hello from WSL2 Vagrant provider!"
+    whoami
+    uname -a
+    echo "Test completed successfully"
+  SHELL
+end

--- a/test/cookbooks/test-cookbook/recipes/default.rb
+++ b/test/cookbooks/test-cookbook/recipes/default.rb
@@ -1,0 +1,31 @@
+# Test Chef recipe for WSL2 provider
+
+log "Chef provisioner test started" do
+  level :info
+end
+
+# Create a test file
+file "/home/vagrant/chef-test.txt" do
+  content "#{node['test']['message']}\nChef provisioner completed successfully on #{node['hostname']}\n"
+  owner "vagrant"
+  group "vagrant"
+  mode "0644"
+  action :create
+end
+
+# Install a package
+package "tree" do
+  action :install
+end
+
+# Create a directory
+directory "/home/vagrant/chef-test" do
+  owner "vagrant"
+  group "vagrant"
+  mode "0755"
+  action :create
+end
+
+log "Chef provisioner test completed" do
+  level :info
+end

--- a/test/salt/minion
+++ b/test/salt/minion
@@ -1,0 +1,5 @@
+# Salt minion configuration for WSL2 testing
+file_client: local
+file_roots:
+  base:
+    - /vagrant/salt/states

--- a/test/salt/states/test-salt.sls
+++ b/test/salt/states/test-salt.sls
@@ -1,0 +1,26 @@
+# Test Salt state for WSL2 provider
+
+salt_test_message:
+  cmd.run:
+    - name: echo "Hello from SaltStack on WSL2!" > /home/vagrant/salt-test.txt
+    - user: vagrant
+    - cwd: /home/vagrant
+    - creates: /home/vagrant/salt-test.txt
+
+install_curl:
+  pkg.installed:
+    - name: curl
+
+create_salt_test_directory:
+  file.directory:
+    - name: /home/vagrant/salt-test
+    - user: vagrant
+    - group: vagrant
+    - mode: 755
+
+salt_test_completion:
+  cmd.run:
+    - name: echo "SaltStack provisioner completed successfully on $(hostname)" >> /home/vagrant/salt-test.txt
+    - user: vagrant
+    - require:
+      - cmd: salt_test_message

--- a/test/salt/states/top.sls
+++ b/test/salt/states/top.sls
@@ -1,0 +1,3 @@
+base:
+  '*':
+    - test-salt

--- a/test/test-distros/Vagrantfile
+++ b/test/test-distros/Vagrantfile
@@ -5,8 +5,24 @@
 DISTRIBUTIONS = [
   "AlmaLinux-8",
   "AlmaLinux-9",
-  "AlmaLinux-Kitten-10",
-  "AlmaLinux-10",
+
+# ==> almalinuxkitten10: Running provisioner: ansible_local...
+# /usr/bin/which: invalid option -- 's'
+# /usr/bin/dnf
+# curl: (22) The requested URL returned error: 404
+# error: skipping https://dl.fedoraproject.org/pub/epel/epel-release-latest-1.noarch.rpm - transfer failed
+# No error message
+  # "AlmaLinux-Kitten-10",
+
+# ==> almalinux10: Running provisioner: ansible_local...
+#     almalinux10: Installing Ansible...
+# /usr/bin/which: invalid option -- 's'
+# /usr/bin/dnf
+# curl: (22) The requested URL returned error: 404
+# error: skipping https://dl.fedoraproject.org/pub/epel/epel-release-latest-1.noarch.rpm - transfer failed
+# No error message
+  # "AlmaLinux-10",
+
   "Debian",
   "FedoraLinux-42",
 
@@ -28,7 +44,12 @@ DISTRIBUTIONS = [
   
   "Ubuntu",
   "Ubuntu-24.04",
-  "archlinux",
+
+# ==> archlinux: Running provisioner: ansible_local...
+#     archlinux: Installing Ansible...
+# bash: line 1: sudo: command not found
+# No error message  
+  # "archlinux",
   "kali-linux",
   "openSUSE-Tumbleweed",
 
@@ -54,17 +75,11 @@ DISTRIBUTIONS = [
 # Distro in the old wsl store
   # "Ubuntu-22.04",
 
-# ==> oraclelinux79: Creating WSL2 distribution: vagrant-test-oraclelinux79
-# ==> oraclelinux79: Using WSL distribution: OracleLinux_7_9
-# ==> oraclelinux79: Creating clean base distribution: OracleLinux_7_9-vagrant-base
-# ==> oraclelinux79: Installing fresh WSL distribution: OracleLinux_7_9
-# wsl: Örökölt disztribúciós regisztráció használata. Fontolja meg inkább tar-alapú disztribúció használatát.
-# Letöltés: Oracle Linux 7.9
-# Oracle Linux 7.9 letöltve.
-# A terjesztés telepítése sikerült. A wsl.exe -d Oracle Linux 7.9 használatával indítható el
-# Failed to install WSL distribution 'OracleLinux_7_9': Distribution 'OracleLinux_7_9' not found after installation completed. Check if installation was successful.
-
-# Untested
+# Oracle Linux - ALL VERSIONS ARE LEGACY DISTRIBUTIONS
+# Bug: --no-launch flag does NOT properly register legacy distributions
+# wsl --install -d OracleLinux_8_10 --no-launch → installed but NOT in wsl -l
+# wsl --install -d OracleLinux_8_10 (interactive) → appears in wsl -l
+# Legacy distributions require interactive setup (username/password prompt)
   # "OracleLinux_7_9",
   # "OracleLinux_8_10",
   # "OracleLinux_9_5"
@@ -101,12 +116,12 @@ Vagrant.configure("2") do |config|
       node.vm.provision "file", source: "../test-file.txt", destination: "/home/vagrant/uploaded-file-test.txt"
 
       # Test ansible_local provisioner (commented out for faster testing)
-      # node.vm.provision "ansible_local" do |ansible|
-      #   ansible.playbook = "../test-playbook.yml"
-      #   ansible.verbose = true
-      #   ansible.install = true
-      #   ansible.install_mode = :default  # Use apt instead of pip on Ubuntu
-      # end
+      node.vm.provision "ansible_local" do |ansible|
+        ansible.playbook = "test-playbook.yml"
+        ansible.verbose = true
+        ansible.install = true
+        ansible.install_mode = :default  # Use apt instead of pip on Ubuntu
+      end
 
       # Show provisioning results
       node.vm.provision "shell", inline: <<-SHELL

--- a/test/test-distros/Vagrantfile
+++ b/test/test-distros/Vagrantfile
@@ -1,0 +1,124 @@
+# Test Vagrantfile for WSL2 Provider Provisioner Testing
+# Tests shell, file, and ansible provisioners across available WSL2 distributions
+
+# WSL2 distributions available for testing (from wsl --list --online)
+DISTRIBUTIONS = [
+  "AlmaLinux-8",
+  "AlmaLinux-9",
+  "AlmaLinux-Kitten-10",
+  "AlmaLinux-10",
+  "Debian",
+  "FedoraLinux-42",
+
+#   ==> suselinuxenterprise15sp6: Running provisioner: file...
+# The guest operating system of the machine could not be detected!
+# Vagrant requires this knowledge to perform specific tasks such
+# as mounting shared folders and configuring networks. Please add
+# the ability to detect this guest operating system to Vagrant
+# by creating a plugin or reporting a bug.
+  # "SUSE-Linux-Enterprise-15-SP6",
+
+# ==> suselinuxenterprise15sp7: Keeping existing default distribution: vagrant-test-almalinux8
+# ==> suselinuxenterprise15sp7: WSL2 distribution created successfully
+# ==> suselinuxenterprise15sp7: WSL2 distribution is already running
+# ==> suselinuxenterprise15sp7: Setting up shared folders for WSL2 distribution
+# ==> suselinuxenterprise15sp7: Creating shared folder: . -> /vagrant
+# No error message
+  # "SUSE-Linux-Enterprise-15-SP7",
+  
+  "Ubuntu",
+  "Ubuntu-24.04",
+  "archlinux",
+  "kali-linux",
+  "openSUSE-Tumbleweed",
+
+# ==> opensuseleap156: WSL2 distribution created successfully
+# ==> opensuseleap156: WSL2 distribution is already running
+# ==> opensuseleap156: Setting up shared folders for WSL2 distribution
+# ==> opensuseleap156: Creating shared folder: . -> /vagrant
+# No error message
+  # "openSUSE-Leap-15.6",
+
+# ==> ubuntu2004: Using WSL distribution: Ubuntu-20.04
+# ==> ubuntu2004: Creating clean base distribution: Ubuntu-20.04-vagrant-base
+# ==> ubuntu2004: Installing fresh WSL distribution: Ubuntu-20.04
+# Failed to install WSL distribution 'Ubuntu-20.04': Distribution 'Ubuntu-20.04' not found after installation completed. Check if installation was successful.  
+# Distro in the old wsl store
+  # "Ubuntu-20.04",
+
+  # ==> ubuntu2204: Creating WSL2 distribution: vagrant-test-ubuntu2204
+# ==> ubuntu2204: Using WSL distribution: Ubuntu-22.04
+# ==> ubuntu2204: Creating clean base distribution: Ubuntu-22.04-vagrant-base
+# ==> ubuntu2204: Installing fresh WSL distribution: Ubuntu-22.04
+# Failed to install WSL distribution 'Ubuntu-22.04': Distribution 'Ubuntu-22.04' not found after installation completed. Check if installation was successful.
+# Distro in the old wsl store
+  # "Ubuntu-22.04",
+
+# ==> oraclelinux79: Creating WSL2 distribution: vagrant-test-oraclelinux79
+# ==> oraclelinux79: Using WSL distribution: OracleLinux_7_9
+# ==> oraclelinux79: Creating clean base distribution: OracleLinux_7_9-vagrant-base
+# ==> oraclelinux79: Installing fresh WSL distribution: OracleLinux_7_9
+# wsl: Örökölt disztribúciós regisztráció használata. Fontolja meg inkább tar-alapú disztribúció használatát.
+# Letöltés: Oracle Linux 7.9
+# Oracle Linux 7.9 letöltve.
+# A terjesztés telepítése sikerült. A wsl.exe -d Oracle Linux 7.9 használatával indítható el
+# Failed to install WSL distribution 'OracleLinux_7_9': Distribution 'OracleLinux_7_9' not found after installation completed. Check if installation was successful.
+
+# Untested
+  # "OracleLinux_7_9",
+  # "OracleLinux_8_10",
+  # "OracleLinux_9_5"
+]
+
+Vagrant.configure("2") do |config|
+  DISTRIBUTIONS.each do |distro|
+    # Clean name for Vagrant machine
+    machine_name = distro.downcase.gsub(/[^a-z0-9]/, '')
+
+    config.vm.define machine_name do |node|
+      # Set the box name to the WSL2 distribution name
+      node.vm.box = distro
+
+      node.vm.provider "wsl2" do |wsl|
+        wsl.distribution_name = "vagrant-test2-#{machine_name}"
+        wsl.memory = 1024
+        wsl.cpus = 1
+      end
+
+      node.vm.synced_folder "../", "/vagrant-shared"
+
+      # Test shell provisioning
+      node.vm.provision "shell", inline: <<-SHELL
+        echo "=== Testing #{distro} ==="
+        echo "Hello from WSL2 Vagrant provider!"
+        whoami
+        uname -a
+        echo "Shell provisioner completed successfully"
+        echo "shell-test" > /home/vagrant/shell-test.txt
+      SHELL
+
+      # Test file provisioner
+      node.vm.provision "file", source: "../test-file.txt", destination: "/home/vagrant/uploaded-file-test.txt"
+
+      # Test ansible_local provisioner (commented out for faster testing)
+      # node.vm.provision "ansible_local" do |ansible|
+      #   ansible.playbook = "../test-playbook.yml"
+      #   ansible.verbose = true
+      #   ansible.install = true
+      #   ansible.install_mode = :default  # Use apt instead of pip on Ubuntu
+      # end
+
+      # Show provisioning results
+      node.vm.provision "shell", inline: <<-SHELL
+        echo "=== Provisioning Results for #{distro} ==="
+        echo "Files in /home/vagrant/:"
+        ls -la /home/vagrant/ | grep -E '(test|ansible|chef)' || echo "No test files found"
+
+        echo "=== Shared Folders ==="
+        ls -la /vagrant-shared/ || echo "Shared folder not accessible"
+
+        echo "=== #{distro} Test Complete ==="
+      SHELL
+    end 
+  end 
+end

--- a/test/test-distros/test-playbook.yml
+++ b/test/test-distros/test-playbook.yml
@@ -1,0 +1,29 @@
+---
+- name: Test Ansible Playbook for WSL2 Provider
+  hosts: all
+  become: yes
+  tasks:
+    - name: Ensure test directory exists
+      file:
+        path: /home/vagrant/ansible-test
+        state: directory
+        owner: vagrant
+        group: vagrant
+        mode: '0755'
+
+    - name: Create test file with Ansible
+      copy:
+        content: "Ansible provisioner working on WSL2!"
+        dest: /home/vagrant/ansible-test/ansible-test.txt
+        owner: vagrant
+        group: vagrant
+        mode: '0644'
+
+    - name: Install a test package
+      package:
+        name: htop
+        state: present
+
+    - name: Display Ansible facts
+      debug:
+        msg: "Ansible provisioning completed on {{ ansible_hostname }} ({{ ansible_distribution }} {{ ansible_distribution_version }})"

--- a/test/test-file.txt
+++ b/test/test-file.txt
@@ -1,0 +1,3 @@
+This is a test file for the file provisioner.
+It should be uploaded to the WSL2 distribution.
+File provisioner test completed successfully!

--- a/test/test-playbook.yml
+++ b/test/test-playbook.yml
@@ -1,0 +1,30 @@
+---
+- name: Test Ansible Playbook for WSL2 Provider
+  hosts: all
+  become: yes
+  tasks:
+    - name: Ensure test directory exists
+      file:
+        path: /home/vagrant/ansible-test
+        state: directory
+        owner: vagrant
+        group: vagrant
+        mode: '0755'
+
+    - name: Create test file with Ansible
+      copy:
+        content: "Ansible provisioner working on WSL2!"
+        dest: /home/vagrant/ansible-test/ansible-test.txt
+        owner: vagrant
+        group: vagrant
+        mode: '0644'
+
+    - name: Install a test package
+      apt:
+        name: htop
+        state: present
+        update_cache: yes
+
+    - name: Display Ansible facts
+      debug:
+        msg: "Ansible provisioning completed on {{ ansible_hostname }} ({{ ansible_distribution }} {{ ansible_distribution_version }})"

--- a/vagrant-wsl2-provider.gemspec
+++ b/vagrant-wsl2-provider.gemspec
@@ -1,0 +1,31 @@
+lib = File.expand_path("lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "vagrant-wsl2-provider/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "vagrant-wsl2-provider"
+  spec.version       = VagrantPlugins::WSL2::VERSION
+  spec.authors       = ["Zoltan Toma"]
+  spec.email         = ["zoltantoma87@gmail.com"]
+
+  spec.summary       = "Vagrant WSL2 provider plugin"
+  spec.description   = "A Vagrant provider plugin for managing WSL2 distributions"
+  spec.homepage      = "https://github.com/LeeShan87/vagrant-wsl2-provider"
+  spec.license       = "MIT"
+
+  spec.metadata["allowed_push_host"] = "https://rubygems.org"
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
+
+  # Specify which files should be added to the gem when it is released.
+  spec.files = Dir["lib/**/*", "locales/**/*", "*.md", "*.txt", "LICENSE", "Rakefile", "Gemfile", "*.gemspec"]
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  # Dependencies
+  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+end


### PR DESCRIPTION
Add comprehensive multi-distro testing and documentation

working commands:
- vagrant up
- vagrant status
- vagrant halt (probably)
- vagrant destroy

Provisioners:
- shel
- file
- ansible
- chef(manual synlinking needed)
- salt? (install url changed since vagrant 2.3.7(MIT))

Tested distributions:
- 8 distros working with shell/file/ansible provisioners
- Documented known issues for legacy/minimal/bleeding-edge distros
