### PR TITLE
Add wsl.conf support and Docker provisioning for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Docker support and systemd enablement on distribution start
+- Comprehensive testing for various Linux distributions (AlmaLinux, Debian, Fedora, Ubuntu, Kali, openSUSE)
+- Configuration support for distribution name, version, memory, CPUs, and GUI
+
+## [0.1.0] - 2025-09-30
+
+### Added
+- Initial release of Vagrant WSL2 provider
+- Basic WSL2 distribution creation and management
+- Integration with Vagrant's standard workflow
+- Support for Windows 10/11 with WSL2
+- Support for shell, file, and Ansible provisioners
+- Distribution compatibility documentation in README
+
+### Features
+- Create and destroy WSL2 distributions
+- Start, stop, and SSH into distributions
+- Vagrant box integration
+- Basic provisioning support
+
+### Known Issues
+- Per-distribution CPU/memory limits not supported (WSL2 limitation)
+- Legacy WSL distributions (Ubuntu-20.04, Ubuntu-22.04, Oracle Linux) require interactive setup
+- Some SUSE Enterprise distributions have guest detection issues
+- AlmaLinux-10 and archlinux have provisioning limitations
+
+[unreleased]: https://github.com/LeeShan87/vagrant-wsl2-provider/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/LeeShan87/vagrant-wsl2-provider/releases/tag/v0.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vagrant-wsl2-provider (0.1.0)
+    vagrant-wsl2-provider (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -107,6 +107,34 @@ wsl -l | Select-String -Pattern '\S' | ForEach-Object { $name = $_.Line -replace
 
 ## Known Issues
 
+### Per-Distribution CPU/Memory Limits Not Supported
+
+**WSL2 does not support per-distribution CPU and memory limits.**
+
+Reference: [Microsoft WSL Issue #8570](https://github.com/microsoft/WSL/issues/8570)
+
+The `memory` and `cpus` configuration options in the Vagrantfile currently do nothing because:
+- CPU/memory limits in WSL2 are configured globally in `%USERPROFILE%\.wslconfig`
+- These limits apply to **ALL** WSL2 distributions simultaneously
+- Microsoft has not implemented per-distribution resource limits
+
+```ruby
+config.vm.provider "wsl2" do |wsl|
+  wsl.memory = 2048  # Currently has no effect
+  wsl.cpus = 2       # Currently has no effect
+end
+```
+
+**Workaround**: Manually configure global limits in `%USERPROFILE%\.wslconfig`:
+
+```ini
+[wsl2]
+memory=4GB
+processors=2
+```
+
+This affects all WSL2 distributions including Docker Desktop and other Vagrant VMs.
+
 ### Legacy WSL Distributions
 
 Some WSL distributions use the legacy registration system and are not fully supported:

--- a/lib/vagrant-wsl2-provider/action/create.rb
+++ b/lib/vagrant-wsl2-provider/action/create.rb
@@ -60,6 +60,10 @@ module VagrantPlugins
           env[:ui].info "Setting up vagrant user and environment"
           setup_vagrant_user(env, config.distribution_name)
 
+          # Apply wsl.conf configuration
+          env[:ui].info "Applying wsl.conf configuration"
+          driver.apply_wsl_conf
+
           # Set the project distribution as default only if cache is currently default
           current_default = get_current_default_distribution
           if current_default == clean_base_name

--- a/lib/vagrant-wsl2-provider/version.rb
+++ b/lib/vagrant-wsl2-provider/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module WSL2
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/test/docker-test/Vagrantfile
+++ b/test/docker-test/Vagrantfile
@@ -1,0 +1,60 @@
+# Multi-VM Vagrantfile for Docker testing with vagrant-wsl2-provider
+# Tests Docker (Moby) installation with systemd support
+
+# Working distributions with ansible_local support
+DISTRIBUTIONS = [
+  "AlmaLinux-8",
+  "AlmaLinux-9",
+  "Debian",
+  "FedoraLinux-42",  
+  "Ubuntu",
+  "Ubuntu-24.04",
+  "kali-linux",
+  "openSUSE-Tumbleweed",
+]
+
+Vagrant.configure("2") do |config|
+  DISTRIBUTIONS.each do |distro|
+    # Clean name for Vagrant machine
+    machine_name = "docker-#{distro.downcase.gsub(/[^a-z0-9]/, '')}"
+
+    config.vm.define machine_name do |node|
+      node.vm.box = distro
+
+      node.vm.provider "wsl2" do |wsl|
+        wsl.distribution_name = "vagrant-#{machine_name}"
+        wsl.version = 2
+        wsl.memory = 2048
+        wsl.cpus = 2
+
+        # Enable systemd - required for Docker
+        wsl.systemd = true
+        wsl.default_user = "vagrant"
+        wsl.hostname = machine_name
+      end
+
+      # Install Docker using Ansible
+      node.vm.provision "ansible_local" do |ansible|
+        ansible.playbook = "docker-playbook.yml"
+        ansible.verbose = true
+        ansible.install = true
+        ansible.install_mode = :default
+      end
+
+      # Test Docker installation
+      node.vm.provision "shell", inline: <<-SHELL
+        echo "=== Testing Docker Installation on #{distro} ==="
+        sudo systemctl status docker --no-pager
+        echo ""
+        echo "=== Running hello-world container ==="
+        sudo docker run hello-world
+        echo ""
+        echo "=== Docker Info ==="
+        sudo docker --version
+        sudo docker info | grep -E "Server Version|Storage Driver|Cgroup Driver"
+        echo ""
+        echo "=== #{distro} Docker Test Complete ==="
+      SHELL
+    end
+  end
+end

--- a/test/docker-test/Vagrantfile
+++ b/test/docker-test/Vagrantfile
@@ -33,9 +33,16 @@ Vagrant.configure("2") do |config|
         wsl.hostname = machine_name
       end
 
-      # Install Docker using Ansible
+      # Install Docker using Ansible (OS-specific playbook)
+      playbook = case distro
+                 when /Ubuntu|Debian|kali/i then "provisioning/docker-debian.yml"
+                 when /AlmaLinux|Fedora/i then "provisioning/docker-redhat.yml"
+                 when /openSUSE/i then "provisioning/docker-suse.yml"
+                 else "provisioning/docker-debian.yml"  # default fallback
+                 end
+
       node.vm.provision "ansible_local" do |ansible|
-        ansible.playbook = "docker-playbook.yml"
+        ansible.playbook = playbook
         ansible.verbose = true
         ansible.install = true
         ansible.install_mode = :default

--- a/test/docker-test/docker-playbook.yml
+++ b/test/docker-test/docker-playbook.yml
@@ -1,0 +1,98 @@
+---
+- name: Install Docker (Moby) with systemd support
+  hosts: all
+  become: yes
+  tasks:
+    - name: Update package cache
+      package:
+        update_cache: yes
+      ignore_errors: yes
+
+    - name: Install required packages
+      package:
+        name:
+          - ca-certificates
+          - curl
+          - gnupg
+          - iptables
+        state: present
+
+    - name: Add Microsoft GPG key (Debian/Ubuntu)
+      shell: |
+        curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+      when: ansible_os_family == "Debian"
+
+    - name: Add Microsoft Moby repository (Debian/Ubuntu)
+      shell: |
+        curl -fsSL https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | tee /etc/apt/sources.list.d/microsoft-prod.list
+      when: ansible_os_family == "Debian"
+
+    - name: Update package cache after adding repository
+      package:
+        update_cache: yes
+      ignore_errors: yes
+
+    - name: Install Moby Docker (Debian/Ubuntu)
+      package:
+        name:
+          - moby-engine
+          - moby-cli
+          - moby-containerd
+          - moby-runc
+        state: present
+      when: ansible_os_family == "Debian"
+
+    - name: Install Docker (RedHat/AlmaLinux/Fedora)
+      package:
+        name:
+          - docker
+        state: present
+      when: ansible_os_family == "RedHat"
+
+    - name: Install Docker (openSUSE)
+      package:
+        name:
+          - docker
+        state: present
+      when: ansible_os_family == "Suse"
+
+    - name: Ensure containerd is enabled and started (Debian/Ubuntu)
+      systemd:
+        name: containerd
+        enabled: yes
+        state: started
+        daemon_reload: yes
+      when: ansible_os_family == "Debian"
+
+    - name: Check if docker group exists
+      command: getent group docker
+      register: docker_group_check
+      changed_when: false
+      failed_when: false
+
+    - name: Add vagrant user to docker group
+      user:
+        name: vagrant
+        groups: docker
+        append: yes
+      when: docker_group_check.rc == 0
+
+    - name: Enable and start Docker service
+      systemd:
+        name: docker
+        enabled: yes
+        state: started
+        daemon_reload: yes
+
+    - name: Wait for Docker to be ready
+      wait_for:
+        timeout: 10
+
+    - name: Verify Docker is running
+      command: docker info
+      register: docker_info
+      changed_when: false
+
+    - name: Show Docker version
+      debug:
+        msg: "Docker is installed and running"

--- a/test/docker-test/provisioning/docker-debian.yml
+++ b/test/docker-test/provisioning/docker-debian.yml
@@ -1,15 +1,15 @@
 ---
-- name: Install Docker (Moby) with systemd support
+- name: Install Docker (Moby) on Debian-based systems
   hosts: all
   become: yes
   tasks:
     - name: Update package cache
-      package:
+      apt:
         update_cache: yes
-      ignore_errors: yes
+        cache_valid_time: 3600
 
     - name: Install required packages
-      package:
+      apt:
         name:
           - ca-certificates
           - curl
@@ -17,65 +17,59 @@
           - iptables
         state: present
 
-    - name: Add Microsoft GPG key (Debian/Ubuntu)
-      shell: |
-        curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
-      when: ansible_os_family == "Debian"
+    - name: Check if Ubuntu
+      shell: grep -q Ubuntu /etc/os-release && echo "ubuntu" || echo "debian"
+      register: distro_type
+      changed_when: false
 
-    - name: Add Microsoft Moby repository (Debian/Ubuntu)
+    - name: Add Microsoft GPG key (Ubuntu only)
+      shell: |
+        curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor --batch | tee /usr/share/keyrings/microsoft-prod.gpg > /dev/null
+      args:
+        creates: /usr/share/keyrings/microsoft-prod.gpg
+      when: distro_type.stdout == "ubuntu"
+
+    - name: Add Microsoft Moby repository (Ubuntu only)
       shell: |
         curl -fsSL https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | tee /etc/apt/sources.list.d/microsoft-prod.list
-      when: ansible_os_family == "Debian"
+      args:
+        creates: /etc/apt/sources.list.d/microsoft-prod.list
+      when: distro_type.stdout == "ubuntu"
 
     - name: Update package cache after adding repository
-      package:
+      apt:
         update_cache: yes
-      ignore_errors: yes
 
-    - name: Install Moby Docker (Debian/Ubuntu)
-      package:
+    - name: Install Moby Docker (Ubuntu)
+      apt:
         name:
           - moby-engine
           - moby-cli
           - moby-containerd
           - moby-runc
         state: present
-      when: ansible_os_family == "Debian"
+      when: distro_type.stdout == "ubuntu"
 
-    - name: Install Docker (RedHat/AlmaLinux/Fedora)
-      package:
+    - name: Install Docker from default repos (Debian/Kali)
+      apt:
         name:
-          - docker
+          - docker.io
+          - containerd
         state: present
-      when: ansible_os_family == "RedHat"
+      when: distro_type.stdout == "debian"
 
-    - name: Install Docker (openSUSE)
-      package:
-        name:
-          - docker
-        state: present
-      when: ansible_os_family == "Suse"
-
-    - name: Ensure containerd is enabled and started (Debian/Ubuntu)
+    - name: Ensure containerd is enabled and started
       systemd:
         name: containerd
         enabled: yes
         state: started
         daemon_reload: yes
-      when: ansible_os_family == "Debian"
-
-    - name: Check if docker group exists
-      command: getent group docker
-      register: docker_group_check
-      changed_when: false
-      failed_when: false
 
     - name: Add vagrant user to docker group
       user:
         name: vagrant
         groups: docker
         append: yes
-      when: docker_group_check.rc == 0
 
     - name: Enable and start Docker service
       systemd:
@@ -83,10 +77,6 @@
         enabled: yes
         state: started
         daemon_reload: yes
-
-    - name: Wait for Docker to be ready
-      wait_for:
-        timeout: 10
 
     - name: Verify Docker is running
       command: docker info

--- a/test/docker-test/provisioning/docker-redhat.yml
+++ b/test/docker-test/provisioning/docker-redhat.yml
@@ -1,0 +1,32 @@
+---
+- name: Install Podman on RedHat-based systems
+  hosts: all
+  become: yes
+  tasks:
+    - name: Update package cache
+      dnf:
+        update_cache: yes
+
+    - name: Install required packages
+      dnf:
+        name:
+          - ca-certificates
+          - curl
+          - iptables
+        state: present
+
+    - name: Install Podman (Docker compatible)
+      dnf:
+        name:
+          - podman
+          - podman-docker
+        state: present
+
+    - name: Verify Podman is working
+      command: podman info
+      register: podman_info
+      changed_when: false
+
+    - name: Show Podman version
+      debug:
+        msg: "Podman is installed (Docker CLI compatibility enabled)"

--- a/test/docker-test/provisioning/docker-suse.yml
+++ b/test/docker-test/provisioning/docker-suse.yml
@@ -1,0 +1,40 @@
+---
+- name: Install Docker on openSUSE
+  hosts: all
+  become: yes
+  tasks:
+    - name: Install required packages
+      zypper:
+        name:
+          - ca-certificates
+          - curl
+          - iptables
+        state: present
+
+    - name: Install Docker
+      zypper:
+        name:
+          - docker
+        state: present
+
+    - name: Add vagrant user to docker group
+      user:
+        name: vagrant
+        groups: docker
+        append: yes
+
+    - name: Enable and start Docker service
+      systemd:
+        name: docker
+        enabled: yes
+        state: started
+        daemon_reload: yes
+
+    - name: Verify Docker is running
+      command: docker info
+      register: docker_info
+      changed_when: false
+
+    - name: Show Docker version
+      debug:
+        msg: "Docker is installed and running"

--- a/vagrant-wsl2-provider.gemspec
+++ b/vagrant-wsl2-provider.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
+  spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
 
   # Specify which files should be added to the gem when it is released.
   spec.files = Dir["lib/**/*", "locales/**/*", "*.md", "*.txt", "LICENSE", "Rakefile", "Gemfile", "*.gemspec"]


### PR DESCRIPTION
- Implement wsl.conf configuration with dotted syntax (wsl.systemd = true)
- Add systemd support with proper WSL2 restart (wsl --shutdown)
- Create OS-specific Ansible playbooks for Docker installation
  - docker-debian.yml: Ubuntu/Debian/Kali (Microsoft Moby)
  - docker-redhat.yml: AlmaLinux/Fedora (Podman)
  - docker-suse.yml: openSUSE (Docker)
- Fix Docker networking by installing iptables package
- Test Docker provisioning on 8 distributions
- Update version to 0.2.0