### PR TITLE
fix vagrant machine state management. and vagrant status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Distribution names now persist across Vagrant commands (fixes #8)
+- `vagrant ssh` and other commands now remember auto-generated distribution names
+- `vagrant halt` properly shows "stopped" status instead of waking up the distribution
+- State checking no longer wakes up stopped distributions
+- `vagrant ssh` commands now silently auto-start stopped distributions without verbose output
+
+### Changed
+- Distribution names default to box name (e.g., "Ubuntu") instead of random timestamp
+- Added collision detection: appends timestamp if box name already exists as a distribution
+- Added `wsl.name` as a convenience alias for `wsl.distribution_name`
+- SSH commands now accept WSL2's auto-shutdown behavior and start distributions silently when needed
+
+### Added
+- Silent distribution startup for SSH commands to prevent output pollution
+- `EnsureRunning` action for transparent VM wake-up on SSH access
+
 ## [0.4.0] - 2025-11-24
 
 ### Changed

--- a/examples/basic/Vagrantfile
+++ b/examples/basic/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "Ubuntu-24.04"
 
   config.vm.provider "wsl2" do |wsl|
-    wsl.distribution_name = "vagrant-wsl2-basic"
+    wsl.name = "vagrant-wsl2-basic"
     wsl.version = 2
   end
 end

--- a/lib/vagrant-wsl2-provider/action/create.rb
+++ b/lib/vagrant-wsl2-provider/action/create.rb
@@ -14,9 +14,24 @@ module VagrantPlugins
           config = machine.provider_config
           driver = env[:wsl2_driver]
 
+          # Generate distribution name if not explicitly set
+          if !config.distribution_name
+            # Use box name as the default distribution name
+            box_name = machine.config.vm.box
+
+            # Check if a distribution with this name already exists (collision check)
+            if wsl_distribution_installed?(box_name)
+              # Name collision: append timestamp to make it unique
+              config.distribution_name = "#{box_name}_#{Time.now.to_i}"
+              env[:ui].warn "Distribution '#{box_name}' already exists, using '#{config.distribution_name}' instead"
+            else
+              config.distribution_name = box_name
+            end
+          end
+
           env[:ui].info "Creating WSL2 distribution: #{config.distribution_name}"
 
-          # Check if distribution already exists
+          # Check if distribution already exists (and it's not ours)
           if driver.state != :not_created
             raise Errors::DistributionAlreadyExists,
                   name: config.distribution_name

--- a/lib/vagrant-wsl2-provider/action/ensure_running.rb
+++ b/lib/vagrant-wsl2-provider/action/ensure_running.rb
@@ -1,0 +1,26 @@
+module VagrantPlugins
+  module WSL2
+    module Action
+      # Silently ensure the WSL2 distribution is running
+      # This is used by SSH commands when the distribution is stopped
+      # WSL2 automatically stops idle distributions, so this is expected behavior
+      class EnsureRunning
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          driver = env[:wsl2_driver]
+
+          # Only start if stopped, do nothing if already running
+          # Use silent: true to avoid polluting SSH command output
+          if driver.state == :stopped
+            driver.start(silent: true)
+          end
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-wsl2-provider/communicator.rb
+++ b/lib/vagrant-wsl2-provider/communicator.rb
@@ -102,7 +102,9 @@ module VagrantPlugins
 
         begin
           # Build the wsl command with parsed bash flags
-          wsl_args = ["wsl", "--distribution", config.distribution_name, "-u", "vagrant",
+          # Use machine.id (persisted) or fallback to config.distribution_name
+          distribution_name = @machine.id || config.distribution_name
+          wsl_args = ["wsl", "--distribution", distribution_name, "-u", "vagrant",
           "--exec", "bash", bash_flags, wrapped_command]
 
           # Execute the command
@@ -167,7 +169,8 @@ module VagrantPlugins
 
         # Get the distribution's filesystem root path
         # WSL distributions are accessible at \\wsl$\<distro-name>\
-        wsl_network_path = "\\\\wsl$\\#{config.distribution_name}"
+        distribution_name = @machine.id || config.distribution_name
+        wsl_network_path = "\\\\wsl$\\#{distribution_name}"
 
         # Ensure the distribution is running
         unless driver.state == :running
@@ -230,7 +233,8 @@ module VagrantPlugins
         end
 
         # Get the source path in WSL network share
-        wsl_network_path = "\\\\wsl$\\#{config.distribution_name}"
+        distribution_name = @machine.id || config.distribution_name
+        wsl_network_path = "\\\\wsl$\\#{distribution_name}"
         from_normalized = from.start_with?('/') ? from[1..-1] : from
         source_path = File.join(wsl_network_path, from_normalized)
 

--- a/lib/vagrant-wsl2-provider/config.rb
+++ b/lib/vagrant-wsl2-provider/config.rb
@@ -69,6 +69,10 @@ module VagrantPlugins
       # WSL2 distribution name
       attr_accessor :distribution_name
 
+      # Alias for distribution_name for convenience
+      alias_method :name, :distribution_name
+      alias_method :name=, :distribution_name=
+
       # WSL2 version (1 or 2)
       attr_accessor :version
 
@@ -148,7 +152,9 @@ module VagrantPlugins
       end
 
       def finalize!
-        @distribution_name = "vagrant-#{Time.now.to_i}" if @distribution_name == UNSET_VALUE
+        # Default distribution_name will be set to nil and generated during Create action
+        # This prevents generating a new random name on every command
+        @distribution_name = nil if @distribution_name == UNSET_VALUE
         @version = 2 if @version == UNSET_VALUE
         @memory = 4096 if @memory == UNSET_VALUE
         @cpus = 2 if @cpus == UNSET_VALUE
@@ -160,8 +166,8 @@ module VagrantPlugins
       def validate(machine)
         errors = _detected_errors
 
-        # Validate distribution name
-        if @distribution_name.to_s.strip.empty?
+        # Validate distribution name (skip if nil, will be auto-generated)
+        if @distribution_name && @distribution_name.to_s.strip.empty?
           errors << "Distribution name cannot be empty"
         end
 

--- a/lib/vagrant-wsl2-provider/driver.rb
+++ b/lib/vagrant-wsl2-provider/driver.rb
@@ -9,21 +9,31 @@ module VagrantPlugins
         @config = machine.provider_config
       end
 
+      # Get the distribution name, preferring machine.id if it exists
+      def distribution_name
+        @machine.id || @config.distribution_name
+      end
+
       # Get the current state of the WSL2 distribution
       def state
-        # Check if distribution exists by trying to get its state
-        result = Vagrant::Util::Subprocess.execute("wsl", "--distribution", @config.distribution_name, "--exec", "echo")
+        # Return :not_created if we don't have a distribution name yet
+        return :not_created unless distribution_name
 
-        case result.exit_code
-        when 0
-          # Distribution exists and is accessible, check if running
-          running_result = Vagrant::Util::Subprocess.execute("wsl", "--distribution", @config.distribution_name, "--exec", "true")
-          return running_result.exit_code == 0 ? :running : :stopped
-        when 1, 4294967295
-          # Distribution doesn't exist or WSL error
-          :not_created
+        # Use wsl --list --verbose to check state without waking up the distribution
+        result = execute_safe("wsl", "--list", "--verbose")
+        return :not_created unless result
+
+        distributions = parse_wsl_list_output(result.stdout)
+        distro = distributions.find { |d| d[:name] == distribution_name }
+
+        return :not_created unless distro
+
+        case distro[:state]
+        when "Running"
+          :running
+        when "Stopped"
+          :stopped
         else
-          # Unknown error state
           :unknown
         end
       rescue
@@ -37,25 +47,26 @@ module VagrantPlugins
         FileUtils.mkdir_p(dist_dir) unless File.exist?(dist_dir)
 
         # Import the distribution from a tar.gz file
-        execute("wsl", "--import", @config.distribution_name,
+        execute("wsl", "--import", distribution_name,
                 dist_dir, box_path, "--version", @config.version.to_s)
       end
 
       # Start the WSL2 distribution
-      def start
-        @machine.ui.info "Starting WSL2 distribution: #{@config.distribution_name}"
-        execute("wsl", "--distribution", @config.distribution_name, "--exec", "true")
+      # @param silent [Boolean] If true, suppress UI output
+      def start(silent: false)
+        @machine.ui.info "Starting WSL2 distribution: #{distribution_name}" unless silent
+        execute("wsl", "--distribution", distribution_name, "--exec", "true")
       end
 
       # Stop the WSL2 distribution
       def halt
-        @machine.ui.info "Stopping WSL2 distribution: #{@config.distribution_name}"
-        execute("wsl", "--terminate", @config.distribution_name)
+        @machine.ui.info "Stopping WSL2 distribution: #{distribution_name}"
+        execute("wsl", "--terminate", distribution_name)
       end
 
       # Destroy the WSL2 distribution
       def destroy
-        execute("wsl", "--unregister", @config.distribution_name)
+        execute("wsl", "--unregister", distribution_name)
 
         # Wait a moment for WSL to release file handles
         sleep 1
@@ -82,7 +93,7 @@ module VagrantPlugins
 
       # Execute a command in the WSL2 distribution
       def execute_in_wsl(*args)
-        execute("wsl", "--distribution", @config.distribution_name, *args)
+        execute("wsl", "--distribution", distribution_name, *args)
       end
 
       # Public wrapper for execute method (for use by actions)
@@ -139,7 +150,7 @@ module VagrantPlugins
 
         # Export the current distribution to a tar file
         @machine.ui.info "Saving snapshot: #{snapshot_name}"
-        execute("wsl", "--export", @config.distribution_name, snapshot_file)
+        execute("wsl", "--export", distribution_name, snapshot_file)
 
         @machine.ui.success "Snapshot saved: #{snapshot_name}"
       end
@@ -156,13 +167,13 @@ module VagrantPlugins
 
         # First, unregister the current distribution
         halt if state == :running
-        execute("wsl", "--unregister", @config.distribution_name)
+        execute("wsl", "--unregister", distribution_name)
 
         # Import the snapshot as the distribution
         dist_dir = distribution_path
         FileUtils.mkdir_p(dist_dir) unless File.exist?(dist_dir)
 
-        execute("wsl", "--import", @config.distribution_name,
+        execute("wsl", "--import", distribution_name,
                 dist_dir, snapshot_file, "--version", @config.version.to_s)
 
         @machine.ui.success "Snapshot restored: #{snapshot_name}"
@@ -267,7 +278,7 @@ module VagrantPlugins
         # Count block devices that could be data disks (sde and later)
         # Use wsl -d to run command inside the distribution
         result = Vagrant::Util::Subprocess.execute(
-          "wsl", "-d", @config.distribution_name, "--", "lsblk", "-nd", "-o", "NAME"
+          "wsl", "-d", distribution_name, "--", "lsblk", "-nd", "-o", "NAME"
         )
         return false if result.exit_code != 0
 
@@ -423,6 +434,39 @@ module VagrantPlugins
       # Get the path where this distribution should be stored
       def distribution_path
         @machine.data_dir.join("wsl2_distribution").to_s
+      end
+
+      # Parse WSL list output to extract distribution information
+      def parse_wsl_list_output(output)
+        distributions = []
+
+        # Handle UTF-16LE encoding from WSL on Windows
+        output = output.force_encoding('UTF-16LE').encode('UTF-8', invalid: :replace, undef: :replace)
+
+        lines = output.lines.map(&:strip).reject(&:empty?)
+
+        # Find the header line (NAME STATE VERSION)
+        header_index = lines.find_index { |line| line.match?(/NAME.*STATE.*VERSION/i) }
+        return distributions unless header_index
+
+        # Parse distribution lines after the header
+        lines[(header_index + 1)..-1].each do |line|
+          # Remove default marker (*) and null bytes
+          line = line.gsub(/\*/, '').gsub(/\0/, '').strip
+          next if line.empty?
+
+          # Split by whitespace and extract fields
+          parts = line.split(/\s+/)
+          next if parts.length < 3
+
+          distributions << {
+            name: parts[0],
+            state: parts[1],
+            version: parts[2]
+          }
+        end
+
+        distributions
       end
     end
   end

--- a/lib/vagrant-wsl2-provider/provider.rb
+++ b/lib/vagrant-wsl2-provider/provider.rb
@@ -9,6 +9,7 @@ module VagrantPlugins
       autoload :Destroy, File.expand_path("../action/destroy", __FILE__)
       autoload :Halt, File.expand_path("../action/halt", __FILE__)
       autoload :Start, File.expand_path("../action/start", __FILE__)
+      autoload :EnsureRunning, File.expand_path("../action/ensure_running", __FILE__)
       autoload :PrepareEnvironment, File.expand_path("../action/prepare_environment", __FILE__)
       autoload :WSLShell, File.expand_path("../action/wsl_shell", __FILE__)
       autoload :ShareFolders, File.expand_path("../action/share_folders", __FILE__)
@@ -165,16 +166,9 @@ module VagrantPlugins
       def action_ssh
         Vagrant::Action::Builder.new.tap do |b|
           b.use Vagrant::Action::Builtin::ConfigValidate
-          b.use Vagrant::Action::Builtin::Call, Vagrant::Action::Builtin::IsState, :running do |env, b2|
-            if env[:result]
-              b2.use Action::PrepareEnvironment
-              b2.use Action::WSLShell
-            else
-              env[:ui].info("Machine is not running, starting it up...")
-              b2.use action_up
-              b2.use Action::WSLShell
-            end
-          end
+          b.use Action::PrepareEnvironment
+          b.use Action::EnsureRunning
+          b.use Action::WSLShell
         end
       end
 
@@ -182,16 +176,9 @@ module VagrantPlugins
       def action_ssh_run
         Vagrant::Action::Builder.new.tap do |b|
           b.use Vagrant::Action::Builtin::ConfigValidate
-          b.use Vagrant::Action::Builtin::Call, Vagrant::Action::Builtin::IsState, :running do |env, b2|
-            if env[:result]
-              b2.use Action::PrepareEnvironment
-              b2.use Action::SSHRun
-            else
-              env[:ui].info("Machine is not running, starting it up...")
-              b2.use action_up
-              b2.use Action::SSHRun
-            end
-          end
+          b.use Action::PrepareEnvironment
+          b.use Action::EnsureRunning
+          b.use Action::SSHRun
         end
       end
 

--- a/test/integration/Basic.Tests.ps1
+++ b/test/integration/Basic.Tests.ps1
@@ -48,13 +48,13 @@ Describe "Vagrant WSL2 Provider - Basic Operations" {
         }
 
         It "Should execute commands via 'vagrant ssh -c'" {
-            $sshOutput = vagrant ssh -c "echo 'SSH test successful'" 2>&1
+            $sshOutput = (vagrant ssh -c "echo 'SSH test successful'" 2>&1) -join "`n"
             $LASTEXITCODE | Should -Be 0
             $sshOutput | Should -Match "SSH test successful"
         }
 
         It "Should handle SSH commands with pipes" {
-            $output = vagrant ssh -c "echo 'test' | grep 'test'" 2>&1
+            $output = (vagrant ssh -c "echo 'test' | grep 'test'" 2>&1) -join "`n"
             $LASTEXITCODE | Should -Be 0
             $output | Should -Match "test"
         }

--- a/test/integration/Init.Tests.ps1
+++ b/test/integration/Init.Tests.ps1
@@ -4,7 +4,8 @@
 
 BeforeAll {
     $script:ExampleDir = Join-Path $PSScriptRoot "..\..\examples\init"
-    $script:DistributionName = "vagrant-wsl2-init"
+    # Default distribution name should be the box name
+    $script:DistributionName = "Ubuntu"
     $script:VagrantfilePath = Join-Path $script:ExampleDir "Vagrantfile"
 
     # Ensure we're in the correct directory
@@ -52,8 +53,9 @@ Describe "Vagrant WSL2 Provider - Init Workflow" {
             $LASTEXITCODE | Should -Be 0
         }
 
-        It "Should create WSL distribution" {
+        It "Should create WSL distribution using box name" {
             $wslList = (wsl -l -v | Out-String) -replace '\0', ''
+            # Distribution name should be the box name (Ubuntu)
             $wslList | Should -Match $script:DistributionName
         }
 

--- a/test/integration/MultiVmNetwork.Tests.ps1
+++ b/test/integration/MultiVmNetwork.Tests.ps1
@@ -52,10 +52,12 @@ Describe "Vagrant WSL2 Provider - Multi-VM Networking" -Skip:(-not $isAdminCheck
             $LASTEXITCODE | Should -Be 0 -Because "vagrant up should start both VMs"
         }
 
-        It "Should show both VMs in running state" {
+        It "Should show both VMs as created" {
             $status = (vagrant status) -join "`n"
-            $status | Should -Match "vm1.*running" -Because "vm1 should be running"
-            $status | Should -Match "vm2.*running" -Because "vm2 should be running"
+            # WSL2 may auto-stop idle distributions, so we check for existence rather than running state
+            # The VMs should not show "not created" - they can be either "running" or "stopped"
+            $status | Should -Match "vm1\s+(running|stopped)" -Because "vm1 should be created"
+            $status | Should -Match "vm2\s+(running|stopped)" -Because "vm2 should be created"
         }
     }
 
@@ -92,8 +94,8 @@ Describe "Vagrant WSL2 Provider - Multi-VM Networking" -Skip:(-not $isAdminCheck
     Context "When verifying VM isolation" {
 
         It "Should have independent hostnames for each VM" {
-            $vm1_hostname = vagrant ssh vm1 -c "hostname" 2>$null
-            $vm2_hostname = vagrant ssh vm2 -c "hostname" 2>$null
+            $vm1_hostname = (vagrant ssh vm1 -c "hostname" 2>$null) -join "`n"
+            $vm2_hostname = (vagrant ssh vm2 -c "hostname" 2>$null) -join "`n"
 
             $vm1_hostname = $vm1_hostname.Trim()
             $vm2_hostname = $vm2_hostname.Trim()


### PR DESCRIPTION
Improve WSL2 distribution naming and state management

- Use box name as default distribution name instead of timestamps
- Persist distribution names across Vagrant commands using machine.id
- Add collision detection with timestamp suffix for duplicate names
- Fix state checking to avoid waking stopped distributions
- Implement silent auto-start for SSH commands
- Add `wsl.name` as alias for `wsl.distribution_name`
- Add EnsureRunning action for transparent VM wake-up
- Update tests to handle auto-stopped distributions

Fixes #8
Fixes #11 